### PR TITLE
Feature: Implement CRUD Operations for Session Resource with Soft Deletion

### DIFF
--- a/src/common/enums/SessionStatus.enum.ts
+++ b/src/common/enums/SessionStatus.enum.ts
@@ -2,5 +2,5 @@ export enum SessionStatus {
     PENDING = 'pending',
     ACTIVE = 'active',
     COMPLETED = 'completed',
-    CANCELLED = 'canceled',
+    CANCELED = 'canceled',
 }

--- a/src/sessions/dto/update-session.dto.ts
+++ b/src/sessions/dto/update-session.dto.ts
@@ -1,4 +1,8 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateSessionDto } from './create-session.dto';
+import { ApiProperty, PartialType } from "@nestjs/swagger";
+import { CreateSessionDto } from "./create-session.dto";
+import { SessionStatus } from "src/common/enums/SessionStatus.enum";
 
-export class UpdateSessionDto extends PartialType(CreateSessionDto) {}
+export class UpdateSessionDto extends PartialType(CreateSessionDto) {
+    @ApiProperty({ example: 'completed', description: 'Session status' })
+    status?: SessionStatus;
+}

--- a/src/sessions/providers/sessions.service.ts
+++ b/src/sessions/providers/sessions.service.ts
@@ -1,26 +1,60 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Not } from 'typeorm';
+import { Session } from '../session.entity';
 import { CreateSessionDto } from '../dto/create-session.dto';
 import { UpdateSessionDto } from '../dto/update-session.dto';
+import { SessionStatus } from 'src/common/enums/SessionStatus.enum';
+
+
 
 @Injectable()
 export class SessionsService {
-  create(createSessionDto: CreateSessionDto) {
-    return 'This action adds a new session';
+  constructor(
+    @InjectRepository(Session)
+    private readonly sessionsRepository: Repository<Session>,
+  ) {}
+
+  async createSession(createSessionDto: CreateSessionDto): Promise<Session> {
+    const session = this.sessionsRepository.create({
+      ...createSessionDto,
+      status: SessionStatus.PENDING,
+    });
+    return await this.sessionsRepository.save(session);
   }
 
-  findAll() {
-    return `This action returns all sessions`;
+  async getAllSessions(includeDeleted = false): Promise<Session[]> {
+    return await this.sessionsRepository.find({
+      where: includeDeleted ? {} : { status: Not(SessionStatus.CANCELED) },
+    });
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} session`;
+  async getSessionById(id: number): Promise<Session | null> {
+    return await this.sessionsRepository.findOne({ where: { id } });
   }
 
-  update(id: number, updateSessionDto: UpdateSessionDto) {
-    return `This action updates a #${id} session`;
+  async updateSession(id: number, updateSessionDto: UpdateSessionDto): Promise<Session> {
+    const session = await this.sessionsRepository.findOne({ where: { id } });
+    if (!session) throw new NotFoundException('Session not found');
+
+    if (updateSessionDto.status) {
+      if (!Object.values(SessionStatus).includes(updateSessionDto.status)) {
+        throw new BadRequestException('Invalid session status');
+      }
+      session.status = updateSessionDto.status;
+    }
+
+    Object.assign(session, updateSessionDto);
+    return await this.sessionsRepository.save(session);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} session`;
+  async softDeleteSession(id: number): Promise<{ message: string }> {
+    const session = await this.sessionsRepository.findOne({ where: { id } });
+    if (!session) throw new NotFoundException('Session not found');
+
+    session.status = SessionStatus.CANCELED;
+    await this.sessionsRepository.save(session);
+
+    return { message: 'Session deleted (soft delete applied)' };
   }
 }

--- a/src/sessions/sessions.controller.ts
+++ b/src/sessions/sessions.controller.ts
@@ -1,34 +1,38 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Delete, Body, Param, Query, NotFoundException } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { SessionsService } from './providers/sessions.service';
 import { CreateSessionDto } from './dto/create-session.dto';
 import { UpdateSessionDto } from './dto/update-session.dto';
 
+@ApiTags('Sessions')
 @Controller('sessions')
 export class SessionsController {
   constructor(private readonly sessionsService: SessionsService) {}
 
   @Post()
-  create(@Body() createSessionDto: CreateSessionDto) {
-    return this.sessionsService.create(createSessionDto);
+  async createSession(@Body() createSessionDto: CreateSessionDto) {
+    return await this.sessionsService.createSession(createSessionDto);
   }
 
   @Get()
-  findAll() {
-    return this.sessionsService.findAll();
+  async getAllSessions(@Query('includeDeleted') includeDeleted: boolean) {
+    return await this.sessionsService.getAllSessions(includeDeleted);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.sessionsService.findOne(+id);
+  async getSessionById(@Param('id') id: string) {
+    const session = await this.sessionsService.getSessionById(+id);
+    if (!session) throw new NotFoundException('Session not found');
+    return session;
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateSessionDto: UpdateSessionDto) {
-    return this.sessionsService.update(+id, updateSessionDto);
+  async updateSession(@Param('id') id: string, @Body() updateSessionDto: UpdateSessionDto) {
+    return await this.sessionsService.updateSession(+id, updateSessionDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.sessionsService.remove(+id);
+  async softDeleteSession(@Param('id') id: string) {
+    return await this.sessionsService.softDeleteSession(+id);
   }
 }


### PR DESCRIPTION
In this PR, I introduces the implementation of time-sensitive CRUD operations for the SESSION resource following RESTful principles. Key features include:

✅ Session Management:
POST /sessions → Create a new session (default status: PENDING).
GET /sessions → Fetch all sessions (excluding canceled sessions unless explicitly requested).
GET /sessions/:id → Retrieve a session by its ID.
PATCH /sessions/:id → Update session details & status (e.g., ACTIVE, COMPLETED, CANCELED).
DELETE /sessions/:id → Soft delete a session (mark as CANCELED).

✅ Business Logic & Validations:
Sessions have structured relationships (mentor, mentee).
Validates inputs with DTO (CreateSessionDto).
Uses TypeORM’s Not operator to filter out canceled sessions.
Implements soft deletion instead of permanent removal.

✅ Testing:
Created .http files to test endpoints using httpYac.
Ensured all status transitions work correctly.
Verified soft deletion behavior.

Implementation Details
1️⃣ DTOs & Entities
DTO: CreateSessionDto.ts validates session creation.
Entity: Session.ts defines structure, relationships, and SessionStatus enum.

2️⃣ Soft Deletion Approach
Instead of hard-deleting a session, the DELETE request updates status: CANCELED.
The GET endpoints exclude canceled sessions by default (Not(SessionStatus.CANCELED)).

3️⃣ Status Management
PENDING → ACTIVE → COMPLETED

Supports CANCELED status for soft deletion.

Testing Instructions
1️⃣ Run Migrations
npm run typeorm migration:run

2️⃣ Start Server
npm run start:dev

3️⃣ Test Endpoints with httpYac
POST /sessions → Create session.
PATCH /sessions/:id → Update session status.
DELETE /sessions/:id → Soft delete session.
GET /sessions → Check if deleted sessions are excluded.

closes #23 