### PR TITLE
feat(auth): implement secure forgot password and reset password workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "class-validator": "^0.14.1",
         "dotenv": "^16.4.7",
         "ioredis": "^5.6.0",
+        "nodemailer": "^7.0.3",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.14.1",
@@ -12383,6 +12384,15 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
+      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "class-validator": "^0.14.1",
     "dotenv": "^16.4.7",
     "ioredis": "^5.6.0",
+    "nodemailer": "^7.0.3",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.14.1",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,6 +4,8 @@ import { CreateUserDto } from 'src/user/dto/create-user.dto';
 import { AuthDto } from './dto/sign-in.dto';
 import { ChangePasswordDto } from './dto/change-password.dto';
 import { SignInResponseDto } from './dto/sign-in-response.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 import {
   ApiTags,
   ApiOperation,
@@ -85,5 +87,17 @@ export class AuthController {
   })
   async logout(@Req() req, @Res({ passthrough: true }) res: Response) {
     return this.authService.logout(req.user.userId, res);
+  }
+
+   @Post('forgot-password')
+  async forgotPassword(@Body() dto: ForgotPasswordDto) {
+    await this.authService.forgotPassword(dto.email);
+    return { message: 'If the email exists, a reset link has been sent.' };
+  }
+
+  @Post('reset-password')
+  async resetPassword(@Body() dto: ResetPasswordDto) {
+    await this.authService.resetPassword(dto.token, dto.newPassword);
+    return { message: 'Password successfully reset.' };
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,6 +8,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { UserModule } from '../user/user.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/user/entities/user.entity';
+import { RedisModule } from '../redis/redis.module';
+import { MailerModule } from '../mailer/mailer.module';
 
 @Module({
   imports: [
@@ -15,7 +17,7 @@ import { User } from 'src/user/entities/user.entity';
     PassportModule,
     ConfigModule,
     JwtModule.registerAsync({
-      imports: [ConfigModule],
+      imports: [ConfigModule, RedisModule, MailerModule],
       useFactory: async (config: ConfigService) => ({
         secret: config.get('JWT_SECRET'),
         signOptions: { expiresIn: config.get('JWT_EXPIRES_IN') || '1d' },

--- a/src/auth/dto/forgot-password.dto.ts
+++ b/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,7 @@
+// src/auth/dto/forgot-password.dto.ts
+import { IsEmail } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  email: string;
+}

--- a/src/auth/dto/reset-password.dto.ts
+++ b/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,11 @@
+// src/auth/dto/reset-password.dto.ts
+import { IsString, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @IsString()
+  token: string;
+
+  @IsString()
+  @MinLength(6)
+  newPassword: string;
+}

--- a/src/common/enums/role.enum.ts
+++ b/src/common/enums/role.enum.ts
@@ -1,0 +1,7 @@
+export enum Role {
+    USER = 'USER',
+    ADMIN = 'ADMIN',
+    MENTOR = 'MENTOR',
+    MENTEE = 'MENTEE',
+  }
+  

--- a/src/mailer/mailer.module.ts
+++ b/src/mailer/mailer.module.ts
@@ -1,0 +1,9 @@
+// src/mailer/mailer.module.ts
+import { Module } from '@nestjs/common';
+import { MailerService } from './mailer.service';
+
+@Module({
+  providers: [MailerService],
+  exports: [MailerService],
+})
+export class MailerModule {}

--- a/src/mailer/mailer.service.ts
+++ b/src/mailer/mailer.service.ts
@@ -1,0 +1,25 @@
+// src/mailer/mailer.service.ts
+import { Injectable } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+
+@Injectable()
+export class MailerService {
+  private transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: +process.env.SMTP_PORT || 587,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  async sendResetEmail(to: string, token: string) {
+    const resetUrl = `https://yourdomain.com/reset-password?token=${token}`;
+    const html = `<p>Click <a href="${resetUrl}">here</a> to reset your password. This link expires in 1 hour.</p>`;
+    await this.transporter.sendMail({
+      to,
+      subject: 'Reset Your Password',
+      html,
+    });
+  }
+}

--- a/src/mailer/templates/reset-password.hbs
+++ b/src/mailer/templates/reset-password.hbs
@@ -1,0 +1,2 @@
+<!-- Optional template -->
+<p>Click <a href="{{resetUrl}}">here</a> to reset your password. This link expires in 1 hour.</p>

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -1,0 +1,9 @@
+
+import { Module } from '@nestjs/common';
+import { RedisService } from './redis.service';
+
+@Module({
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class RedisModule {}

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -1,0 +1,26 @@
+
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { createClient } from 'redis';
+
+@Injectable()
+export class RedisService implements OnModuleInit {
+  private client;
+
+  async onModuleInit() {
+    this.client = createClient({ url: process.env.REDIS_URL });
+    this.client.on('error', (err) => console.error('Redis Error', err));
+    await this.client.connect();
+  }
+
+  async set(key: string, value: string, ttlSeconds: number) {
+    await this.client.setEx(key, ttlSeconds, value);
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.client.get(key);
+  }
+
+  async del(key: string): Promise<void> {
+    await this.client.del(key);
+  }
+}

--- a/src/user/providers/user.service.ts
+++ b/src/user/providers/user.service.ts
@@ -125,4 +125,12 @@ export class UserService {
 
     await this.userRepository.update(userId, { profilePicture: imageUrl });
   }
+
+    findByEmail(email: string): Promise<User | null> {
+    return this.userRepository.findOne({ where: { email } });
+  }
+
+  async updatePassword(id: string, password: string): Promise<void> {
+    await this.userRepository.update(id, { password });
+  }
 }


### PR DESCRIPTION
This PR implements a secure "Forgot Password" workflow including:

Endpoint to request password reset via email (POST /auth/forgot-password)

Endpoint to reset password with token (POST /auth/reset-password)

Secure token generation and storage in Redis with expiration

Password hashing with bcrypt before updating

Nodemailer integration for sending reset emails

Proper error handling for invalid or expired tokens

Added DTO validation and updated AuthModule imports


Closes #4o

