### PR TITLE
feat(auth): add RBAC guard and @Roles decorator, protect mentor/admin…

### DIFF
--- a/apps/api/src/auth/decorators/rbac.guard.ts
+++ b/apps/api/src/auth/decorators/rbac.guard.ts
@@ -1,0 +1,47 @@
+import {
+    CanActivate,
+    ExecutionContext,
+    ForbiddenException,
+    Injectable,
+  } from '@nestjs/common';
+  import { Reflector } from '@nestjs/core';
+  import { ROLES_KEY } from '../decorators/roles.decorator';
+  
+  @Injectable()
+  export class RbacGuard implements CanActivate {
+    constructor(private readonly reflector: Reflector) {}
+  
+    canActivate(context: ExecutionContext): boolean {
+      const requiredRoles =
+        this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+          context.getHandler(),
+          context.getClass(),
+        ]);
+  
+      // If no roles are required, allow access
+      if (!requiredRoles || requiredRoles.length === 0) {
+        return true;
+      }
+  
+      const request = context.switchToHttp().getRequest();
+      const user = request.user;
+  
+      const userRoles: string[] | undefined = user?.roles;
+  
+      // Roles are required but user has none
+      if (!userRoles || userRoles.length === 0) {
+        throw new ForbiddenException();
+      }
+  
+      const hasRequiredRole = requiredRoles.some((role) =>
+        userRoles.includes(role),
+      );
+  
+      if (!hasRequiredRole) {
+        throw new ForbiddenException();
+      }
+  
+      return true;
+    }
+  }
+  

--- a/apps/api/src/auth/decorators/roles.decorator.ts
+++ b/apps/api/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+
+export const Roles = (...roles: string[]) =>
+  SetMetadata(ROLES_KEY, roles);

--- a/apps/api/src/auth/guards/jwt-auth.guard.ts
+++ b/apps/api/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,11 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    // For now, just mock a user object
+    request.user = request.user || { sub: 'mock-user-id', roles: ['mentor'] };
+    return true;
+  }
+}

--- a/apps/api/src/controllers/mentor-skill.controller.ts
+++ b/apps/api/src/controllers/mentor-skill.controller.ts
@@ -24,14 +24,20 @@ import { MentorSkillService } from '../services/mentor-skill.service';
 import { AttachSkillDto, UpdateSkillDto } from '../dtos/mentor-skill.dto';
 import { MentorSkill } from '../entities/mentor-skill.entity';
 import { MentorProfile } from '../entities/mentor-profile.entity';
+import { UseGuards } from '@nestjs/common';
+import { RbacGuard } from '../auth/decorators/rbac.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
 
 @ApiTags('mentor-skills')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RbacGuard)
 @Controller('mentor-skills')
 export class MentorSkillController {
   constructor(private readonly mentorSkillService: MentorSkillService) {}
 
   @Post('attach')
+  @Roles('mentor') 
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Attach a skill to mentor profile' })
   @ApiBody({ type: AttachSkillDto })
@@ -53,6 +59,7 @@ export class MentorSkillController {
   @ApiBody({ type: UpdateSkillDto })
   @ApiResponse({ status: 200, description: 'Skill updated successfully' })
   @ApiResponse({ status: 404, description: 'Mentor skill not found' })
+  @Roles('mentor')
   async updateSkill(
     @Request() req: any,
     @Param('skillId') skillId: string,
@@ -80,6 +87,7 @@ export class MentorSkillController {
   @ApiOperation({ summary: 'Get all skills for current mentor' })
   @ApiResponse({ status: 200, description: 'List of mentor skills' })
   @ApiResponse({ status: 404, description: 'Mentor profile not found' })
+  @Roles('mentor')
   async getMentorSkills(@Request() req: any): Promise<MentorSkill[]> {
     const userId = req.user?.sub || 'mock-user-id';
     return await this.mentorSkillService.getMentorSkills(userId);

--- a/apps/api/src/controllers/skill.controller.ts
+++ b/apps/api/src/controllers/skill.controller.ts
@@ -12,13 +12,18 @@ import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/s
 import { SkillService } from '../services/skill.service';
 import { CreateSkillDto } from '../dtos/skill.dto';
 import { Skill } from '../entities/skill.entity';
-
+import { UseGuards } from '@nestjs/common';
+import { RbacGuard } from '../auth/decorators/rbac.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
 @ApiTags('skills')
 @Controller('skills')
+@UseGuards(JwtAuthGuard, RbacGuard)
 export class SkillController {
   constructor(private readonly skillService: SkillService) {}
 
   @Post()
+  @Roles('admin') 
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Create a new skill' })
   @ApiBody({ type: CreateSkillDto })
@@ -54,6 +59,7 @@ export class SkillController {
   }
 
   @Delete(':id')
+  @Roles('admin') 
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a skill' })
   @ApiParam({ name: 'id', description: 'Skill ID' })


### PR DESCRIPTION
This PR implements Issue #83:
- Added @Roles decorator
- Added RbacGuard
- Protected mentor-only routes in MentorSkillController
- Protected admin-only routes in SkillController
- Stubbed JwtAuthGuard to allow testing
closes[#83 ]