### PR TITLE
feat(auth): implement secure refresh token rotation and logout with r…

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -2,19 +2,34 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { User } from '../users/entities/user.entity';
+import { RefreshToken } from './entities/refresh-token.entity';
 
 @Module({
   imports: [
     ConfigModule,
-    TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([RefreshToken, User]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({}), // Config is per-token in the service
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: parseInt(
+            configService.get<string>('JWT_TTL') || '3600',
+            10,
+          ),
+        },
+      }),
+    }),
+    ConfigModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy, JwtRefreshStrategy],

--- a/apps/api/src/auth/dto/refresh-token.dto.ts
+++ b/apps/api/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RefreshTokenDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  refreshToken!: string;
+}

--- a/apps/api/src/auth/entities/refresh-token.entity.ts
+++ b/apps/api/src/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('refresh_tokens')
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  @Index()
+  userId!: string;
+
+  @ManyToOne(() => User, (user) => user.id, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  @Column()
+  tokenHash!: string;
+
+  @Column()
+  expiresAt!: Date;
+
+  @Column({ nullable: true })
+  revokedAt?: Date;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @Column({ nullable: true })
+  userAgent?: string;
+
+  @Column({ nullable: true })
+  ip?: string;
+
+  @Column({ nullable: true })
+  replacedByTokenHash?: string; // useful for tracking rotation chains
+}


### PR DESCRIPTION
## Description

Complete the authentication lifecycle with:

POST /auth/refresh — rotate refresh tokens securely (issue new pair; invalidate old refresh)
POST /auth/logout — revoke current refresh token (server-side)
Introduce a secure refresh token store (e.g., DB table) with token hashing, metadata (user, issuedAt, expiresAt, deviceId/ip), and revocation. Cover happy/sad paths with tests

Closes #81 


<img width="648" height="468" alt="Screenshot 2026-01-23 at 10 07 37" src="https://github.com/user-attachments/assets/d19ca316-841e-4d45-b2c6-1903ec600990" />
