### PR TITLE
Created the Register User System

### DIFF
--- a/src/modules/auth/providers/auth.service.spec.ts
+++ b/src/modules/auth/providers/auth.service.spec.ts
@@ -1,0 +1,107 @@
+import { ConflictException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+describe('AuthService register', () => {
+  let authService: AuthService;
+  let userServiceMock: {
+    findByEmail: jest.Mock;
+    create: jest.Mock;
+  };
+  let mailServiceMock: {
+    sendWelcomeEmail: jest.Mock;
+    sendLoginEmail: jest.Mock;
+  };
+
+  beforeEach(() => {
+    userServiceMock = {
+      findByEmail: jest.fn(),
+      create: jest.fn(),
+    };
+
+    mailServiceMock = {
+      sendWelcomeEmail: jest.fn(),
+      sendLoginEmail: jest.fn(),
+    };
+
+    const nonceServiceMock = {
+      storeNonce: jest.fn(),
+    };
+
+    const configServiceMock = {
+      jwtExpiresIn: '1h',
+      jwtSecret: 'secret',
+    };
+
+    const jwtServiceMock = {
+      sign: jest.fn(),
+    };
+
+    authService = new AuthService(
+      nonceServiceMock as any,
+      configServiceMock as any,
+      userServiceMock as any,
+      mailServiceMock as any,
+      jwtServiceMock as any,
+    );
+  });
+
+  it('creates a new user and sends welcome email', async () => {
+    userServiceMock.findByEmail.mockResolvedValue(null);
+
+    const user = {
+      id: '1',
+      email: 'test@example.com',
+      password: 'hashedpassword',
+      firstName: 'John',
+      lastName: 'Doe',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    userServiceMock.create.mockResolvedValue(user);
+
+    const result = await authService.register({
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'test@example.com',
+      password: 'Password123!',
+      confirmPassword: 'Password123!',
+    } as any);
+
+    expect(userServiceMock.findByEmail).toHaveBeenCalledWith(
+      'test@example.com',
+    );
+    expect(userServiceMock.create).toHaveBeenCalled();
+    expect(mailServiceMock.sendWelcomeEmail).toHaveBeenCalledWith(
+      'test@example.com',
+      'John',
+    );
+    expect((result.user as any).password).toBeUndefined();
+  });
+
+  it('throws ConflictException when user already exists', async () => {
+    const existingUser = {
+      id: '1',
+      email: 'test@example.com',
+      password: 'hashedpassword',
+      firstName: 'John',
+      lastName: 'Doe',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    userServiceMock.findByEmail.mockResolvedValue(existingUser);
+
+    await expect(
+      authService.register({
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'test@example.com',
+        password: 'Password123!',
+        confirmPassword: 'Password123!',
+      } as any),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+});

--- a/src/modules/auth/providers/auth.service.ts
+++ b/src/modules/auth/providers/auth.service.ts
@@ -130,6 +130,12 @@ export class AuthService {
 
     this.logger.log(`New user registered: ${email}`);
 
+    this.mailService
+      .sendWelcomeEmail(user.email, user.firstName)
+      .catch((err) => {
+        this.logger.error(`Failed to send welcome email: ${err.message}`);
+      });
+
     return {
       message: 'User registered successfully',
       user: safeUser as Omit<User, 'password'>,

--- a/src/modules/mail/mail.service.ts
+++ b/src/modules/mail/mail.service.ts
@@ -20,4 +20,9 @@ export class MailService {
     // For now, just simulate success
     return Promise.resolve();
   }
+
+  async sendWelcomeEmail(email: string, userName?: string): Promise<void> {
+    this.logger.log(`Welcome email would be sent to: ${email}`);
+    return Promise.resolve();
+  }
 }


### PR DESCRIPTION
Implemented the Register a User into the system 

Description

Contributor
Module / Path: modules/auth/providers/auth.service.ts
Related DTO: RegisterUserDto (existing)

Description
Implemented user registration logic using the existing DTO, ensuring secure hashing, uniqueness checks, and clean error handling.
The Auth module scaffolding already exists. This task wires up the service logic to create a user account and persist it using the existing repositorypatterns in the codebase.

Tasks:
Create a user Using the Existing Register DTO
Send Welcome email to the User created (email logic is available in src/modules/mail/mai.service.ts)
Acceptance Criteria
Creating a user with a fresh email succeeds and returns a sanitized payload (no password hash).
Creating a user with an existing email (or username) returns 409 Conflict.
Consistent exceptions using NestJS HttpException
Follows existing logging and tracing patterns
PR includes screenshots (if Swagger) and test summary.

closes #183 