### PR TITLE
feat: add many-to-many mentor-skill relation, endpoints, and validati…

### DIFF
--- a/src/modules/mentor_skills/dto/mentor-skills.dto.ts
+++ b/src/modules/mentor_skills/dto/mentor-skills.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsInt, IsArray, ArrayNotEmpty, ArrayUnique } from 'class-validator';
+
+export class AttachSkillsDto {
+  @IsString()
+  mentorId: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsInt({ each: true })
+  skillIds: number[];
+}
+
+export class DetachSkillsDto {
+  @IsString()
+  mentorId: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsInt({ each: true })
+  skillIds: number[];
+}

--- a/src/modules/mentor_skills/entities/mentor-skill.entity.ts
+++ b/src/modules/mentor_skills/entities/mentor-skill.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { MentorProfile } from '../../profile/entities/mentor-profile.entity';
+import { Skill } from '../../skill/entities/skill.entity';
+
+@Entity('mentor_skills')
+export class MentorSkill {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => MentorProfile, mentor => mentor.mentorSkills, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'mentor_id' })
+  mentor: MentorProfile;
+
+  @ManyToOne(() => Skill, skill => skill.mentorSkills, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'skill_id' })
+  skill: Skill;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/mentor_skills/mentor-skills.controller.ts
+++ b/src/modules/mentor_skills/mentor-skills.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Post, Body, Delete, Param } from '@nestjs/common';
+import { MentorSkillsService } from './mentor-skills.service';
+import { AttachSkillsDto, DetachSkillsDto } from './dto/mentor-skills.dto';
+
+@Controller('mentor-skills')
+export class MentorSkillsController {
+  constructor(private readonly mentorSkillsService: MentorSkillsService) {}
+
+  @Post('attach')
+  attachSkills(@Body() dto: AttachSkillsDto) {
+    return this.mentorSkillsService.attachSkills(dto.mentorId, dto.skillIds);
+  }
+
+  @Delete('detach')
+  detachSkills(@Body() dto: DetachSkillsDto) {
+    return this.mentorSkillsService.detachSkills(dto.mentorId, dto.skillIds);
+  }
+}

--- a/src/modules/mentor_skills/mentor-skills.module.ts
+++ b/src/modules/mentor_skills/mentor-skills.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MentorSkillsService } from './mentor-skills.service';
+import { MentorSkillsController } from './mentor-skills.controller';
+import { MentorSkill } from './entities/mentor-skill.entity';
+import { Skill } from '../skill/entities/skill.entity';
+import { MentorProfile } from '../profile/entities/mentor-profile.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MentorSkill, Skill, MentorProfile])],
+  controllers: [MentorSkillsController],
+  providers: [MentorSkillsService],
+  exports: [MentorSkillsService],
+})
+export class MentorSkillsModule {}

--- a/src/modules/mentor_skills/mentor-skills.service.ts
+++ b/src/modules/mentor_skills/mentor-skills.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { MentorSkill } from './entities/mentor-skill.entity';
+import { Skill } from '../skill/entities/skill.entity';
+import { MentorProfile } from '../profile/entities/mentor-profile.entity';
+
+@Injectable()
+export class MentorSkillsService {
+  constructor(
+    @InjectRepository(MentorSkill)
+    private mentorSkillRepo: Repository<MentorSkill>,
+    @InjectRepository(Skill)
+    private skillRepo: Repository<Skill>,
+    @InjectRepository(MentorProfile)
+    private mentorRepo: Repository<MentorProfile>,
+  ) {}
+
+  async attachSkills(mentorId: string, skillIds: number[]) {
+    const mentor = await this.mentorRepo.findOne({ where: { id: mentorId } });
+    if (!mentor) throw new NotFoundException('Mentor not found');
+    const skills = await this.skillRepo.findByIds(skillIds);
+    if (skills.length !== skillIds.length) throw new BadRequestException('Some skills do not exist');
+    const existing = await this.mentorSkillRepo.find({ where: { mentor: { id: mentorId } } });
+    const existingSkillIds = new Set(existing.map(ms => ms.skill.id));
+    const newSkills = skills.filter(skill => !existingSkillIds.has(skill.id));
+    if (!newSkills.length) throw new BadRequestException('All skills already attached');
+    const mentorSkills = newSkills.map(skill => this.mentorSkillRepo.create({ mentor, skill }));
+    return this.mentorSkillRepo.save(mentorSkills);
+  }
+
+  async detachSkills(mentorId: string, skillIds: number[]) {
+    const mentor = await this.mentorRepo.findOne({ where: { id: mentorId } });
+    if (!mentor) throw new NotFoundException('Mentor not found');
+    const mentorSkills = await this.mentorSkillRepo.find({ where: { mentor: { id: mentorId }, skill: { id: In(skillIds) } } });
+    if (!mentorSkills.length) throw new BadRequestException('No matching skills to detach');
+    return this.mentorSkillRepo.remove(mentorSkills);
+  }
+
+  async getMentorSkills(mentorId: string) {
+    const mentorSkills = await this.mentorSkillRepo.find({ where: { mentor: { id: mentorId } }, relations: ['skill'] });
+    return mentorSkills.map(ms => ms.skill);
+  }
+}

--- a/src/modules/profile/entities/mentor-profile.entity.ts
+++ b/src/modules/profile/entities/mentor-profile.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn, CreateDateColumn, UpdateDateColumn, OneToMany } from 'typeorm';
+import { MentorSkill } from '../../mentor_skills/entities/mentor-skill.entity';
 import { IsString, IsOptional, IsArray, IsNumber, IsUrl } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { User } from '../../user/entities/user.entity';
@@ -20,12 +21,8 @@ export class MentorProfile {
   @Column({ type: 'text', nullable: true })
   bio?: string;
 
-  @ApiPropertyOptional({ description: 'List of technical skills', example: ['JavaScript', 'React', 'Node.js', 'TypeScript'] })
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  @Column('text', { array: true, nullable: true })
-  skills?: string[];
+  @OneToMany(() => MentorSkill, mentorSkill => mentorSkill.mentor)
+  mentorSkills: MentorSkill[];
 
   @ApiPropertyOptional({ description: 'Years of experience', example: 5 })
   @IsOptional()

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -41,7 +41,7 @@ export class ProfileController {
       if (mentorProfile) {
         Object.assign(publicProfile, {
           bio: mentorProfile.bio,
-          skills: mentorProfile.skills,
+          skills: mentorProfile.mentorSkills || [],
           experienceYears: mentorProfile.experienceYears,
           title: mentorProfile.title,
           company: mentorProfile.company,

--- a/src/modules/profile/profile.module.ts
+++ b/src/modules/profile/profile.module.ts
@@ -14,6 +14,7 @@ import { ProfileHistoryController } from './profile-history.controller';
 import { AuthModule } from '../auth/auth.module';
 import { UserModule } from '../user/user.module';
 import { UserService } from '../user/providers/user.service';
+import { MentorSkillsModule } from '../mentor_skills/mentor-skills.module';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { MentorProfile } from './entities/mentor-profile.entity';
 import { MenteeProfile } from './entities/mentee-profile.entity';
@@ -29,6 +30,7 @@ import { Wallet } from '../user/entities/wallet.entity';
     MulterModule.register({
       dest: './uploads',
     }),
+    MentorSkillsModule,
   ],
   controllers: [
     ProfileController,

--- a/src/modules/skill/entities/skill.entity.ts
+++ b/src/modules/skill/entities/skill.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from 'typeorm';
+import { MentorSkill } from '../../mentor_skills/entities/mentor-skill.entity';
+
+@Entity('skills')
+export class Skill {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  name: string;
+
+  @OneToMany(() => MentorSkill, mentorSkill => mentorSkill.skill)
+  mentorSkills: MentorSkill[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
Closes #241

## Tasks
Introduce join table mentor_skills (mentor_id, skill_id, timestamps).
Add relations: Mentor ↔ Skill (many-to-many).
Service methods and endpoints to attach/detach skills to mentors.
Validation: only existing skills, prevent duplicates.
## Acceptance Criteria
- [x] A mentor can have multiple skills; a skill can belong to multiple mentors.
- [x] Attaching the same skill twice to a mentor is prevented.
- [x] Mentor profile returns associated skills.