### PR TITLE
feat: add skill categories entity with admin CRUD (#240)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { CacheModule } from './common/cache/cache.module';
 import { CommonModule } from './common/common.module';
 import { HealthModule } from './modules/health/health.module';
 import { AvailabilityModule } from './modules/availability/availability.module';
+import { SkillsModule } from './modules/skills/skills.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { AvailabilityModule } from './modules/availability/availability.module';
     NotificationModule,
     BookingsModule,
     AvailabilityModule,
+    SkillsModule,
     PaymentsModule,
     AuditModule,
     ReviewsModule,

--- a/src/modules/skills/dto/create-skill-category.dto.ts
+++ b/src/modules/skills/dto/create-skill-category.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, MaxLength, Matches, IsOptional } from 'class-validator';
+
+export class CreateSkillCategoryDto {
+  @ApiProperty({ description: 'Category name', example: 'Web Development', maxLength: 100 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    description: 'URL-friendly slug (lowercase letters, numbers, hyphens only)',
+    example: 'web-development',
+    maxLength: 120,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  @Matches(/^[a-z0-9-]+$/, { message: 'slug must contain only lowercase letters, numbers, and hyphens' })
+  slug: string;
+
+  @ApiPropertyOptional({ description: 'Optional category description', example: 'Skills related to building web applications' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/src/modules/skills/dto/create-skill.dto.ts
+++ b/src/modules/skills/dto/create-skill.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, MaxLength, Matches, IsOptional, IsUUID } from 'class-validator';
+
+export class CreateSkillDto {
+  @ApiProperty({ description: 'Skill name', example: 'TypeScript', maxLength: 100 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    description: 'URL-friendly slug (lowercase letters, numbers, hyphens only)',
+    example: 'typescript',
+    maxLength: 120,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  @Matches(/^[a-z0-9-]+$/, { message: 'slug must contain only lowercase letters, numbers, and hyphens' })
+  slug: string;
+
+  @ApiPropertyOptional({ description: 'Optional skill description', example: 'A strongly typed superset of JavaScript' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ description: 'UUID of the category this skill belongs to' })
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+}

--- a/src/modules/skills/dto/update-skill-category.dto.ts
+++ b/src/modules/skills/dto/update-skill-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateSkillCategoryDto } from './create-skill-category.dto';
+
+export class UpdateSkillCategoryDto extends PartialType(CreateSkillCategoryDto) {}

--- a/src/modules/skills/dto/update-skill.dto.ts
+++ b/src/modules/skills/dto/update-skill.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateSkillDto } from './create-skill.dto';
+
+export class UpdateSkillDto extends PartialType(CreateSkillDto) {}

--- a/src/modules/skills/entities/skill-category.entity.ts
+++ b/src/modules/skills/entities/skill-category.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Skill } from './skill.entity';
+
+@Entity('skill_categories')
+@Index(['name'], { unique: true })
+@Index(['slug'], { unique: true })
+export class SkillCategory {
+  @ApiProperty({ description: 'Category unique identifier' })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({ description: 'Category name', example: 'Web Development' })
+  @Column({ type: 'varchar', length: 100, unique: true })
+  name: string;
+
+  @ApiProperty({ description: 'URL-friendly slug', example: 'web-development' })
+  @Column({ type: 'varchar', length: 120, unique: true })
+  slug: string;
+
+  @ApiPropertyOptional({ description: 'Optional category description', example: 'Skills related to building web applications' })
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @ApiProperty({ description: 'Skills belonging to this category', type: () => [Skill] })
+  @OneToMany(() => Skill, (skill) => skill.category, { cascade: false })
+  skills: Skill[];
+
+  @ApiProperty({ description: 'Category creation date' })
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Category last update date' })
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/skills/entities/skill.entity.ts
+++ b/src/modules/skills/entities/skill.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { SkillCategory } from './skill-category.entity';
+
+@Entity('skills')
+@Index(['name'], { unique: true })
+@Index(['slug'], { unique: true })
+export class Skill {
+  @ApiProperty({ description: 'Skill unique identifier' })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({ description: 'Skill name', example: 'TypeScript' })
+  @Column({ type: 'varchar', length: 100, unique: true })
+  name: string;
+
+  @ApiProperty({ description: 'URL-friendly slug', example: 'typescript' })
+  @Column({ type: 'varchar', length: 120, unique: true })
+  slug: string;
+
+  @ApiPropertyOptional({ description: 'Optional skill description', example: 'A strongly typed superset of JavaScript' })
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @ApiPropertyOptional({ description: 'Category this skill belongs to', type: () => SkillCategory })
+  @ManyToOne(() => SkillCategory, (category) => category.skills, {
+    nullable: true,
+    onDelete: 'SET NULL',
+    eager: false,
+  })
+  @JoinColumn()
+  category?: SkillCategory;
+
+  @ApiProperty({ description: 'Skill creation date' })
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Skill last update date' })
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/skills/providers/skill-category.service.ts
+++ b/src/modules/skills/providers/skill-category.service.ts
@@ -1,0 +1,80 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Not, Repository } from 'typeorm';
+import { SkillCategory } from '../entities/skill-category.entity';
+import { CreateSkillCategoryDto } from '../dto/create-skill-category.dto';
+import { UpdateSkillCategoryDto } from '../dto/update-skill-category.dto';
+
+@Injectable()
+export class SkillCategoryService {
+  constructor(
+    @InjectRepository(SkillCategory)
+    private readonly categoryRepo: Repository<SkillCategory>,
+  ) {}
+
+  async create(dto: CreateSkillCategoryDto): Promise<SkillCategory> {
+    await this.assertUnique(dto.name, dto.slug);
+    const category = this.categoryRepo.create(dto);
+    return this.categoryRepo.save(category);
+  }
+
+  findAll(): Promise<SkillCategory[]> {
+    return this.categoryRepo.find({
+      relations: ['skills'],
+      order: { name: 'ASC' },
+    });
+  }
+
+  async findOne(id: string): Promise<SkillCategory> {
+    const category = await this.categoryRepo.findOne({
+      where: { id },
+      relations: ['skills'],
+    });
+    if (!category) {
+      throw new NotFoundException(`Skill category with id "${id}" not found`);
+    }
+    return category;
+  }
+
+  async update(id: string, dto: UpdateSkillCategoryDto): Promise<SkillCategory> {
+    const category = await this.findOne(id);
+    if (dto.name !== undefined || dto.slug !== undefined) {
+      await this.assertUnique(
+        dto.name ?? category.name,
+        dto.slug ?? category.slug,
+        id,
+      );
+    }
+    Object.assign(category, dto);
+    return this.categoryRepo.save(category);
+  }
+
+  async remove(id: string): Promise<void> {
+    const category = await this.findOne(id);
+    await this.categoryRepo.remove(category);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async assertUnique(name: string, slug: string, excludeId?: string): Promise<void> {
+    const byName = await this.categoryRepo.findOne({
+      where: { name, ...(excludeId ? { id: Not(excludeId) } : {}) },
+    });
+    if (byName) {
+      throw new ConflictException(`A category with name "${name}" already exists`);
+    }
+
+    const bySlug = await this.categoryRepo.findOne({
+      where: { slug, ...(excludeId ? { id: Not(excludeId) } : {}) },
+    });
+    if (bySlug) {
+      throw new ConflictException(`A category with slug "${slug}" already exists`);
+    }
+  }
+}

--- a/src/modules/skills/providers/skill.service.ts
+++ b/src/modules/skills/providers/skill.service.ts
@@ -1,0 +1,115 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Not, Repository } from 'typeorm';
+import { Skill } from '../entities/skill.entity';
+import { SkillCategory } from '../entities/skill-category.entity';
+import { CreateSkillDto } from '../dto/create-skill.dto';
+import { UpdateSkillDto } from '../dto/update-skill.dto';
+
+@Injectable()
+export class SkillService {
+  constructor(
+    @InjectRepository(Skill)
+    private readonly skillRepo: Repository<Skill>,
+    @InjectRepository(SkillCategory)
+    private readonly categoryRepo: Repository<SkillCategory>,
+  ) {}
+
+  async create(dto: CreateSkillDto): Promise<Skill> {
+    await this.assertUnique(dto.name, dto.slug);
+
+    let category: SkillCategory | undefined;
+    if (dto.categoryId) {
+      category = await this.categoryRepo.findOne({ where: { id: dto.categoryId } });
+      if (!category) {
+        throw new BadRequestException(`Skill category with id "${dto.categoryId}" not found`);
+      }
+    }
+
+    const skill = this.skillRepo.create({
+      name: dto.name,
+      slug: dto.slug,
+      description: dto.description,
+      category,
+    });
+    return this.skillRepo.save(skill);
+  }
+
+  findAll(categoryId?: string): Promise<Skill[]> {
+    const query = this.skillRepo
+      .createQueryBuilder('skill')
+      .leftJoinAndSelect('skill.category', 'category')
+      .orderBy('skill.name', 'ASC');
+
+    if (categoryId) {
+      query.where('category.id = :categoryId', { categoryId });
+    }
+
+    return query.getMany();
+  }
+
+  async findOne(id: string): Promise<Skill> {
+    const skill = await this.skillRepo.findOne({
+      where: { id },
+      relations: ['category'],
+    });
+    if (!skill) {
+      throw new NotFoundException(`Skill with id "${id}" not found`);
+    }
+    return skill;
+  }
+
+  async update(id: string, dto: UpdateSkillDto): Promise<Skill> {
+    const skill = await this.findOne(id);
+
+    if (dto.name !== undefined || dto.slug !== undefined) {
+      await this.assertUnique(dto.name ?? skill.name, dto.slug ?? skill.slug, id);
+    }
+
+    if (dto.categoryId !== undefined) {
+      if (dto.categoryId === null) {
+        skill.category = undefined;
+      } else {
+        const category = await this.categoryRepo.findOne({ where: { id: dto.categoryId } });
+        if (!category) {
+          throw new BadRequestException(`Skill category with id "${dto.categoryId}" not found`);
+        }
+        skill.category = category;
+      }
+    }
+
+    const { categoryId: _, ...rest } = dto;
+    Object.assign(skill, rest);
+    return this.skillRepo.save(skill);
+  }
+
+  async remove(id: string): Promise<void> {
+    const skill = await this.findOne(id);
+    await this.skillRepo.remove(skill);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async assertUnique(name: string, slug: string, excludeId?: string): Promise<void> {
+    const byName = await this.skillRepo.findOne({
+      where: { name, ...(excludeId ? { id: Not(excludeId) } : {}) },
+    });
+    if (byName) {
+      throw new ConflictException(`A skill with name "${name}" already exists`);
+    }
+
+    const bySlug = await this.skillRepo.findOne({
+      where: { slug, ...(excludeId ? { id: Not(excludeId) } : {}) },
+    });
+    if (bySlug) {
+      throw new ConflictException(`A skill with slug "${slug}" already exists`);
+    }
+  }
+}

--- a/src/modules/skills/skill-category.controller.ts
+++ b/src/modules/skills/skill-category.controller.ts
@@ -1,0 +1,85 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
+import { SkillCategoryService } from './providers/skill-category.service';
+import { CreateSkillCategoryDto } from './dto/create-skill-category.dto';
+import { UpdateSkillCategoryDto } from './dto/update-skill-category.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { Public } from '../auth/decorators/public.decorator';
+import { UserRole } from '../../common/enums/user-role.enum';
+
+@ApiTags('skill-categories')
+@Controller('skill-categories')
+export class SkillCategoryController {
+  constructor(private readonly skillCategoryService: SkillCategoryService) {}
+
+  @Post()
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Create a new skill category (admin only)' })
+  @ApiResponse({ status: 201, description: 'Category created' })
+  @ApiResponse({ status: 409, description: 'Name or slug already exists' })
+  create(@Body() dto: CreateSkillCategoryDto) {
+    return this.skillCategoryService.create(dto);
+  }
+
+  @Get()
+  @Public()
+  @ApiOperation({ summary: 'List all skill categories with their skills' })
+  @ApiResponse({ status: 200, description: 'List of categories' })
+  findAll() {
+    return this.skillCategoryService.findAll();
+  }
+
+  @Get(':id')
+  @Public()
+  @ApiOperation({ summary: 'Get a skill category by ID' })
+  @ApiParam({ name: 'id', description: 'Category UUID' })
+  @ApiResponse({ status: 200, description: 'Category found' })
+  @ApiResponse({ status: 404, description: 'Category not found' })
+  findOne(@Param('id') id: string) {
+    return this.skillCategoryService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Update a skill category (admin only)' })
+  @ApiParam({ name: 'id', description: 'Category UUID' })
+  @ApiResponse({ status: 200, description: 'Category updated' })
+  @ApiResponse({ status: 404, description: 'Category not found' })
+  @ApiResponse({ status: 409, description: 'Name or slug already exists' })
+  update(@Param('id') id: string, @Body() dto: UpdateSkillCategoryDto) {
+    return this.skillCategoryService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Delete a skill category (admin only)' })
+  @ApiParam({ name: 'id', description: 'Category UUID' })
+  @ApiResponse({ status: 200, description: 'Category deleted' })
+  @ApiResponse({ status: 404, description: 'Category not found' })
+  remove(@Param('id') id: string) {
+    return this.skillCategoryService.remove(id);
+  }
+}

--- a/src/modules/skills/skill.controller.ts
+++ b/src/modules/skills/skill.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { SkillService } from './providers/skill.service';
+import { CreateSkillDto } from './dto/create-skill.dto';
+import { UpdateSkillDto } from './dto/update-skill.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { Public } from '../auth/decorators/public.decorator';
+import { UserRole } from '../../common/enums/user-role.enum';
+
+@ApiTags('skills')
+@Controller('skills')
+export class SkillController {
+  constructor(private readonly skillService: SkillService) {}
+
+  @Post()
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Create a new skill (admin only)' })
+  @ApiResponse({ status: 201, description: 'Skill created' })
+  @ApiResponse({ status: 400, description: 'Invalid category ID' })
+  @ApiResponse({ status: 409, description: 'Name or slug already exists' })
+  create(@Body() dto: CreateSkillDto) {
+    return this.skillService.create(dto);
+  }
+
+  @Get()
+  @Public()
+  @ApiOperation({ summary: 'List all skills, optionally filtered by category' })
+  @ApiQuery({ name: 'categoryId', required: false, description: 'Filter by category UUID' })
+  @ApiResponse({ status: 200, description: 'List of skills' })
+  findAll(@Query('categoryId') categoryId?: string) {
+    return this.skillService.findAll(categoryId);
+  }
+
+  @Get(':id')
+  @Public()
+  @ApiOperation({ summary: 'Get a skill by ID' })
+  @ApiParam({ name: 'id', description: 'Skill UUID' })
+  @ApiResponse({ status: 200, description: 'Skill found' })
+  @ApiResponse({ status: 404, description: 'Skill not found' })
+  findOne(@Param('id') id: string) {
+    return this.skillService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Update a skill (admin only)' })
+  @ApiParam({ name: 'id', description: 'Skill UUID' })
+  @ApiResponse({ status: 200, description: 'Skill updated' })
+  @ApiResponse({ status: 404, description: 'Skill not found' })
+  @ApiResponse({ status: 409, description: 'Name or slug already exists' })
+  update(@Param('id') id: string, @Body() dto: UpdateSkillDto) {
+    return this.skillService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Delete a skill (admin only)' })
+  @ApiParam({ name: 'id', description: 'Skill UUID' })
+  @ApiResponse({ status: 200, description: 'Skill deleted' })
+  @ApiResponse({ status: 404, description: 'Skill not found' })
+  remove(@Param('id') id: string) {
+    return this.skillService.remove(id);
+  }
+}

--- a/src/modules/skills/skills.module.ts
+++ b/src/modules/skills/skills.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { SkillCategory } from './entities/skill-category.entity';
+import { Skill } from './entities/skill.entity';
+import { SkillCategoryService } from './providers/skill-category.service';
+import { SkillService } from './providers/skill.service';
+import { SkillCategoryController } from './skill-category.controller';
+import { SkillController } from './skill.controller';
+import { RolesGuard } from '../../common/guards/roles.guard';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([SkillCategory, Skill]),
+    AuthModule,
+  ],
+  controllers: [SkillCategoryController, SkillController],
+  providers: [SkillCategoryService, SkillService, RolesGuard],
+  exports: [SkillCategoryService, SkillService],
+})
+export class SkillsModule {}


### PR DESCRIPTION
## Summary

This PR introduces a structured skill taxonomy to SkillSync by adding `SkillCategory` and `Skill` entities with a one-to-many relationship, replacing the current flat `text[]` skill arrays on profiles with a proper catalogue that admins can manage.

### What was added

- **`SkillCategory` entity** — `id`, `name` (unique), `slug` (unique), `description?`, timestamps. Table: `skill_categories`. Unique DB indexes on `name` and `slug`.
- **`Skill` entity** — `id`, `name` (unique), `slug` (unique), `description?`, `category` (ManyToOne, nullable, `ON DELETE SET NULL`), timestamps. Table: `skills`. Unique DB indexes on `name` and `slug`.
- **Admin CRUD for categories** — `POST /skill-categories`, `GET /skill-categories`, `GET /skill-categories/:id`, `PATCH /skill-categories/:id`, `DELETE /skill-categories/:id`
- **Admin CRUD for skills** — `POST /skills`, `GET /skills`, `GET /skills/:id`, `PATCH /skills/:id`, `DELETE /skills/:id`
- `GET /skills` accepts an optional `?categoryId=` query param to filter skills by category
- GET endpoints are public (`@Public()`); write endpoints require admin JWT
- Uniqueness enforced at both DB level (unique indexes) and application level (`ConflictException` on duplicate name/slug)
- When a category is deleted, its skills remain with `categoryId` set to `NULL` (`ON DELETE SET NULL`)
- Full Swagger/OpenAPI documentation on all endpoints
- `SkillsModule` registered in `AppModule`; TypeORM auto-syncs schema (no manual migrations needed)

## Test plan

- [ ] `POST /skill-categories` with admin JWT → `201 Created`
- [ ] `POST /skill-categories` with the same `name` or `slug` → `409 Conflict`
- [ ] `GET /skill-categories` without a token → `200 OK` with skills relation populated
- [ ] `GET /skill-categories/:id` → `200 OK`; unknown id → `404 Not Found`
- [ ] `PATCH /skill-categories/:id` with admin JWT → `200 OK`, uniqueness re-checked
- [ ] `DELETE /skill-categories/:id` with admin JWT → `200 OK`; verify skills now have `category = null`
- [ ] `POST /skills` with a valid `categoryId` → `201 Created`, skill linked to category
- [ ] `POST /skills` with an invalid `categoryId` → `400 Bad Request`
- [ ] `GET /skills?categoryId=<uuid>` → filtered list for that category
- [ ] `GET /skills` without token → `200 OK`
- [ ] `POST /skill-categories` or `POST /skills` with non-admin token → `403 Forbidden`
- [ ] Server starts without errors (`npm run start:dev`) and Swagger shows `skill-categories` and `skills` tags

Closes #240
