### PR TITLE
impelemented the lisy

### DIFF
--- a/src/modules/service-listing/dto/create-service-listing.dto.ts
+++ b/src/modules/service-listing/dto/create-service-listing.dto.ts
@@ -1,5 +1,5 @@
 import { IsString, IsNumber, IsEnum, IsOptional } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ServiceCategory } from '../entities/service-listing.entity';
 
 export class CreateServiceListingDto {

--- a/src/modules/service-listing/dto/toggle-featured.dto.ts
+++ b/src/modules/service-listing/dto/toggle-featured.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export class ToggleFeaturedDto {
+  @ApiProperty({ description: 'Featured status', example: true })
+  @IsBoolean()
+  isFeatured: boolean;
+}

--- a/src/modules/service-listing/entities/service-listing.entity.ts
+++ b/src/modules/service-listing/entities/service-listing.entity.ts
@@ -61,6 +61,10 @@ export class ServiceListing {
   @Column({ default: true })
   isActive: boolean;
 
+  @ApiPropertyOptional({ description: 'Whether the listing is featured' })
+  @Column({ default: false })
+  isFeatured: boolean;
+
   @ApiProperty({ description: 'Soft delete flag' })
   @Column({ default: false })
   isDeleted: boolean;

--- a/src/modules/service-listing/service-listing.controller.ts
+++ b/src/modules/service-listing/service-listing.controller.ts
@@ -3,12 +3,16 @@ import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagg
 import { ServiceListingService } from './service-listing.service';
 import { CreateServiceListingDto } from './dto/create-service-listing.dto';
 import { UpdateServiceListingDto } from './dto/update-service-listing.dto';
+import { ToggleFeaturedDto } from './dto/toggle-featured.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { UserRole } from '../../common/enums/user-role.enum';
 
 @ApiTags('service-listings')
 @ApiBearerAuth()
 @Controller('service-listings')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class ServiceListingController {
   constructor(private readonly serviceListingService: ServiceListingService) {}
 
@@ -41,6 +45,16 @@ export class ServiceListingController {
   @ApiResponse({ status: 404, description: 'Service listing not found' })
   update(@Param('id') id: string, @Body() updateServiceListingDto: UpdateServiceListingDto, @Request() req) {
     return this.serviceListingService.update(id, updateServiceListingDto, req.user.id);
+  }
+
+  @Patch(':id/featured')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Toggle featured status for a service listing (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Featured status updated successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin access required' })
+  @ApiResponse({ status: 404, description: 'Service listing not found' })
+  toggleFeatured(@Param('id') id: string, @Body() toggleFeaturedDto: ToggleFeaturedDto) {
+    return this.serviceListingService.toggleFeatured(id, toggleFeaturedDto.isFeatured);
   }
 
   @Delete(':id')

--- a/src/modules/service-listing/service-listing.module.ts
+++ b/src/modules/service-listing/service-listing.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ServiceListingController } from './service-listing.controller';
 import { ServiceListingService } from './service-listing.service';
 import { ServiceListing } from './entities/service-listing.entity';
+import { RolesGuard } from '../../common/guards/roles.guard';
 
 @Module({
   imports: [TypeOrmModule.forFeature([ServiceListing])],
   controllers: [ServiceListingController],
-  providers: [ServiceListingService],
+  providers: [ServiceListingService, RolesGuard],
   exports: [ServiceListingService],
 })
 export class ServiceListingModule {}

--- a/src/modules/service-listing/service-listing.service.ts
+++ b/src/modules/service-listing/service-listing.service.ts
@@ -23,7 +23,7 @@ export class ServiceListingService {
   findAll(): Promise<ServiceListing[]> {
     return this.serviceListingRepository.find({
       where: { isDeleted: false },
-      order: { createdAt: 'DESC' },
+      order: { isFeatured: 'DESC', createdAt: 'DESC' },
     });
   }
 
@@ -66,5 +66,18 @@ export class ServiceListingService {
     // Soft delete
     serviceListing.isDeleted = true;
     await this.serviceListingRepository.save(serviceListing);
+  }
+
+  async toggleFeatured(id: string, isFeatured: boolean): Promise<ServiceListing> {
+    const serviceListing = await this.serviceListingRepository.findOne({
+      where: { id, isDeleted: false },
+    });
+
+    if (!serviceListing) {
+      throw new NotFoundException('Service listing not found');
+    }
+
+    serviceListing.isFeatured = isFeatured;
+    return this.serviceListingRepository.save(serviceListing);
   }
 }


### PR DESCRIPTION
Implemented featured listings in the service-listing module. Listings now persist an isFeatured flag on the entity at service-listing.entity.ts (line 64), and the list query now orders by featured first, then newest at service-listing.service.ts (line 23). That satisfies the priority-display requirement and the acceptance criterion that featured listings appear first.

I also added an admin-only endpoint PATCH /service-listings/:id/featured in service-listing.controller.ts (line 50) using @Roles(UserRole.ADMIN), with the request body DTO in toggle-featured.dto.ts. The module now provides RolesGuard in service-listing.module.ts (line 6).

Closes #266 