### PR TITLE
Admin skill moderation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/multer": "^2.0.0",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^3.0.3",
+        "cache-manager": "^7.2.8",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "ejs": "^3.1.10",
@@ -736,6 +737,25 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.0",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -2130,6 +2150,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -4768,6 +4794,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cache-manager": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
+      "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.3.3",
+        "keyv": "^5.5.5"
+      }
+    },
+    "node_modules/cache-manager/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -6773,6 +6818,18 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "license": "ISC"
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -6793,6 +6850,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/multer": "^2.0.0",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^3.0.3",
+    "cache-manager": "^7.2.8",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "ejs": "^3.1.10",

--- a/src/common/enums/skill-status.enum.ts
+++ b/src/common/enums/skill-status.enum.ts
@@ -1,0 +1,5 @@
+export enum SkillStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+}

--- a/src/migration/1700000000001-AddSkillModerationFields.ts
+++ b/src/migration/1700000000001-AddSkillModerationFields.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSkillModerationFields1700000000001 implements MigrationInterface {
+    name = 'AddSkillModerationFields1700000000001'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Add moderation status column with default 'pending'
+        await queryRunner.query(`
+            ALTER TABLE skills 
+            ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'pending';
+        `);
+
+        // Add rejection reason column
+        await queryRunner.query(`
+            ALTER TABLE skills 
+            ADD COLUMN IF NOT EXISTS "rejectionReason" TEXT;
+        `);
+
+        // Add moderated by column (UUID of admin)
+        await queryRunner.query(`
+            ALTER TABLE skills 
+            ADD COLUMN IF NOT EXISTS "moderatedBy" UUID;
+        `);
+
+        // Add moderated at timestamp
+        await queryRunner.query(`
+            ALTER TABLE skills 
+            ADD COLUMN IF NOT EXISTS "moderatedAt" TIMESTAMP WITH TIME ZONE;
+        `);
+
+        // Create index on status for faster filtering
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS idx_skills_status ON skills(status);
+        `);
+
+        // Set existing skills to 'approved' status (backward compatibility)
+        await queryRunner.query(`
+            UPDATE skills SET status = 'approved' WHERE status = 'pending';
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS idx_skills_status;`);
+        await queryRunner.query(`ALTER TABLE skills DROP COLUMN IF EXISTS "moderatedAt";`);
+        await queryRunner.query(`ALTER TABLE skills DROP COLUMN IF EXISTS "moderatedBy";`);
+        await queryRunner.query(`ALTER TABLE skills DROP COLUMN IF EXISTS "rejectionReason";`);
+        await queryRunner.query(`ALTER TABLE skills DROP COLUMN IF EXISTS status;`);
+    }
+}

--- a/src/modules/mentor_skills/mentor-skills.service.ts
+++ b/src/modules/mentor_skills/mentor-skills.service.ts
@@ -5,6 +5,7 @@ import { MentorSkill } from './entities/mentor-skill.entity';
 import { Skill } from '../skill/entities/skill.entity';
 import { MentorProfile } from '../profile/entities/mentor-profile.entity';
 import { SkillPopularityService } from '../skills/providers/skill-popularity.service';
+import { SkillStatus } from '../../common/enums/skill-status.enum';
 
 @Injectable()
 export class MentorSkillsService {
@@ -21,8 +22,19 @@ export class MentorSkillsService {
   async attachSkills(mentorId: string, skillIds: number[]) {
     const mentor = await this.mentorRepo.findOne({ where: { id: mentorId } });
     if (!mentor) throw new NotFoundException('Mentor not found');
+    
     const skills = await this.skillRepo.findByIds(skillIds);
     if (skills.length !== skillIds.length) throw new BadRequestException('Some skills do not exist');
+    
+    // Validate that all skills are approved
+    const nonApprovedSkills = skills.filter(s => s.status !== SkillStatus.APPROVED);
+    if (nonApprovedSkills.length > 0) {
+      const nonApprovedNames = nonApprovedSkills.map(s => s.name).join(', ');
+      throw new BadRequestException(
+        `Cannot attach non-approved skills: ${nonApprovedNames}. Skills must be approved before use.`,
+      );
+    }
+    
     const existing = await this.mentorSkillRepo.find({ where: { mentor: { id: mentorId } } });
     const existingSkillIds = new Set(existing.map(ms => ms.skill.id));
     const newSkills = skills.filter(skill => !existingSkillIds.has(skill.id));

--- a/src/modules/skill/entities/skill.entity.ts
+++ b/src/modules/skill/entities/skill.entity.ts
@@ -1,6 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany, ManyToMany, JoinTable, ManyToOne, JoinColumn, Index } from 'typeorm';
 import { Tag } from '../../tag/entities/tag.entity';
 import { MentorSkill } from '../../mentor_skills/entities/mentor-skill.entity';
+import { SkillStatus } from '../../../common/enums/skill-status.enum';
 
 @Entity('skills')
 @Index(['slug'], { unique: true })
@@ -39,4 +40,24 @@ export class Skill {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  // ---------------------------------------------------------------------------
+  // Moderation fields
+  // ---------------------------------------------------------------------------
+
+  @Column({
+    type: 'enum',
+    enum: SkillStatus,
+    default: SkillStatus.PENDING,
+  })
+  status: SkillStatus;
+
+  @Column({ type: 'text', nullable: true })
+  rejectionReason?: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  moderatedBy?: string;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  moderatedAt?: Date;
 }

--- a/src/modules/skill/skill.service.ts
+++ b/src/modules/skill/skill.service.ts
@@ -1,11 +1,12 @@
 import { Injectable, NotFoundException, Inject } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
-import { Cache } from 'cache-manager';
+import type { Cache } from 'cache-manager';
 
 import { Skill } from './entities/skill.entity';
 import { Tag } from '../tag/entities/tag.entity';
 import { SkillPopularityService } from '../skills/providers/skill-popularity.service';
+import { SkillStatus } from '../../common/enums/skill-status.enum';
 
 export interface RecommendedSkill {
   id: number;
@@ -51,7 +52,8 @@ export class SkillService {
     const qb = this.skillRepo.createQueryBuilder('skill')
       .leftJoinAndSelect('skill.tags', 'tag')
       .addSelect(`ts_rank(skill.searchVector, plainto_tsquery('english', :q))`, 'rank')
-      .where(`skill.searchVector @@ plainto_tsquery('english', :q)`, { q: query });
+      .where(`skill.searchVector @@ plainto_tsquery('english', :q)`, { q: query })
+      .andWhere('skill.status = :status', { status: SkillStatus.APPROVED });
 
     if (tags && tags.length > 0) {
       tags.forEach((slug, i) => {
@@ -87,7 +89,7 @@ export class SkillService {
   // -------------------------------------
   async findById(id: number): Promise<Skill> {
     const skill = await this.skillRepo.findOne({
-      where: { id },
+      where: { id, status: SkillStatus.APPROVED },
       relations: ['tags'],
     });
 
@@ -100,7 +102,7 @@ export class SkillService {
 
   async findBySlug(slug: string): Promise<Skill> {
     const skill = await this.skillRepo.findOne({
-      where: { slug },
+      where: { slug, status: SkillStatus.APPROVED },
       relations: ['tags'],
     });
 
@@ -139,8 +141,9 @@ export class SkillService {
 
     const days = this.resolveWindowToDays(window);
 
-    // ✅ 2. Fetch all skills (lightweight)
+    // ✅ 2. Fetch all skills (lightweight) - only approved
     const skills = await this.skillRepo.find({
+      where: { status: SkillStatus.APPROVED },
       select: ['id', 'name', 'slug'],
     });
 
@@ -206,6 +209,7 @@ export class SkillService {
       .createQueryBuilder('skill')
       .leftJoinAndSelect('skill.tags', 'tag')
       .where('skill.id != :currentId', { currentId: currentSkill.id })
+      .andWhere('skill.status = :status', { status: SkillStatus.APPROVED })
       .getMany();
 
     if (!allSkills.length) return [];

--- a/src/modules/skills/dto/reject-skill.dto.ts
+++ b/src/modules/skills/dto/reject-skill.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength, IsOptional } from 'class-validator';
+
+export class RejectSkillDto {
+  @ApiProperty({ 
+    description: 'Reason for rejecting the skill', 
+    example: 'This skill already exists under a different name',
+    maxLength: 500 
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  reason: string;
+}

--- a/src/modules/skills/entities/skill.entity.ts
+++ b/src/modules/skills/entities/skill.entity.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SkillCategory } from './skill-category.entity';
+import { SkillStatus } from '../../../common/enums/skill-status.enum';
 
 @Entity('skills')
 @Index(['name'], { unique: true })
@@ -47,4 +48,28 @@ export class Skill {
   @ApiProperty({ description: 'Skill last update date' })
   @UpdateDateColumn()
   updatedAt: Date;
+
+  // ---------------------------------------------------------------------------
+  // Moderation fields
+  // ---------------------------------------------------------------------------
+
+  @ApiProperty({ description: 'Skill moderation status', enum: SkillStatus, example: SkillStatus.PENDING })
+  @Column({
+    type: 'enum',
+    enum: SkillStatus,
+    default: SkillStatus.PENDING,
+  })
+  status: SkillStatus;
+
+  @ApiPropertyOptional({ description: 'Reason for rejection if status is rejected' })
+  @Column({ type: 'text', nullable: true })
+  rejectionReason?: string;
+
+  @ApiPropertyOptional({ description: 'UUID of the admin who moderated this skill' })
+  @Column({ type: 'uuid', nullable: true })
+  moderatedBy?: string;
+
+  @ApiPropertyOptional({ description: 'Date when the skill was moderated' })
+  @Column({ type: 'timestamptz', nullable: true })
+  moderatedAt?: Date;
 }

--- a/src/modules/skills/providers/skill.service.ts
+++ b/src/modules/skills/providers/skill.service.ts
@@ -3,13 +3,16 @@ import {
   NotFoundException,
   ConflictException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Not, Repository } from 'typeorm';
+import { Not, Repository, In } from 'typeorm';
 import { Skill } from '../entities/skill.entity';
 import { SkillCategory } from '../entities/skill-category.entity';
 import { CreateSkillDto } from '../dto/create-skill.dto';
 import { UpdateSkillDto } from '../dto/update-skill.dto';
+import { RejectSkillDto } from '../dto/reject-skill.dto';
+import { SkillStatus } from '../../../common/enums/skill-status.enum';
 
 @Injectable()
 export class SkillService {
@@ -41,14 +44,19 @@ export class SkillService {
     return this.skillRepo.save(skill);
   }
 
-  findAll(categoryId?: string): Promise<Skill[]> {
+  findAll(categoryId?: string, includeAllStatuses: boolean = false): Promise<Skill[]> {
     const query = this.skillRepo
       .createQueryBuilder('skill')
       .leftJoinAndSelect('skill.category', 'category')
       .orderBy('skill.name', 'ASC');
 
+    // By default, only return approved skills for public access
+    if (!includeAllStatuses) {
+      query.andWhere('skill.status = :status', { status: SkillStatus.APPROVED });
+    }
+
     if (categoryId) {
-      query.where('category.id = :categoryId', { categoryId });
+      query.andWhere('category.id = :categoryId', { categoryId });
     }
 
     return query.getMany();
@@ -92,6 +100,95 @@ export class SkillService {
   async remove(id: string): Promise<void> {
     const skill = await this.findOne(id);
     await this.skillRepo.remove(skill);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Moderation methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Find all pending skills awaiting moderation
+   */
+  async findPending(): Promise<Skill[]> {
+    return this.skillRepo.find({
+      where: { status: SkillStatus.PENDING },
+      relations: ['category'],
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  /**
+   * Approve a skill (admin only)
+   */
+  async approve(id: string, adminId: string): Promise<Skill> {
+    const skill = await this.findOne(id);
+
+    if (skill.status === SkillStatus.APPROVED) {
+      throw new BadRequestException('Skill is already approved');
+    }
+
+    skill.status = SkillStatus.APPROVED;
+    skill.moderatedBy = adminId;
+    skill.moderatedAt = new Date();
+    skill.rejectionReason = undefined;
+
+    return this.skillRepo.save(skill);
+  }
+
+  /**
+   * Reject a skill (admin only)
+   */
+  async reject(id: string, adminId: string, dto: RejectSkillDto): Promise<Skill> {
+    const skill = await this.findOne(id);
+
+    if (skill.status === SkillStatus.REJECTED) {
+      throw new BadRequestException('Skill is already rejected');
+    }
+
+    skill.status = SkillStatus.REJECTED;
+    skill.rejectionReason = dto.reason;
+    skill.moderatedBy = adminId;
+    skill.moderatedAt = new Date();
+
+    return this.skillRepo.save(skill);
+  }
+
+  /**
+   * Find one skill by ID (with status check for public access)
+   */
+  async findOnePublic(id: string): Promise<Skill> {
+    const skill = await this.findOne(id);
+
+    if (skill.status !== SkillStatus.APPROVED) {
+      throw new NotFoundException(`Skill with id "${id}" not found`);
+    }
+
+    return skill;
+  }
+
+  /**
+   * Check if skills exist and are approved
+   */
+  async validateSkillsForAttachment(skillIds: string[]): Promise<Skill[]> {
+    const skills = await this.skillRepo.find({
+      where: { id: In(skillIds) },
+    });
+
+    if (skills.length !== skillIds.length) {
+      const foundIds = skills.map(s => s.id);
+      const missingIds = skillIds.filter(id => !foundIds.includes(id));
+      throw new BadRequestException(`Skills not found: ${missingIds.join(', ')}`);
+    }
+
+    const nonApprovedSkills = skills.filter(s => s.status !== SkillStatus.APPROVED);
+    if (nonApprovedSkills.length > 0) {
+      const nonApprovedNames = nonApprovedSkills.map(s => s.name).join(', ');
+      throw new BadRequestException(
+        `Cannot attach non-approved skills: ${nonApprovedNames}. Skills must be approved before use.`,
+      );
+    }
+
+    return skills;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/modules/skills/skill.controller.ts
+++ b/src/modules/skills/skill.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Query,
   UseGuards,
+  Request,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -20,11 +21,13 @@ import {
 import { SkillService } from './providers/skill.service';
 import { CreateSkillDto } from './dto/create-skill.dto';
 import { UpdateSkillDto } from './dto/update-skill.dto';
+import { RejectSkillDto } from './dto/reject-skill.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { Public } from '../auth/decorators/public.decorator';
 import { UserRole } from '../../common/enums/user-role.enum';
+import { SkillStatus } from '../../common/enums/skill-status.enum';
 
 @ApiTags('skills')
 @Controller('skills')
@@ -59,7 +62,7 @@ export class SkillController {
   @ApiResponse({ status: 200, description: 'Skill found' })
   @ApiResponse({ status: 404, description: 'Skill not found' })
   findOne(@Param('id') id: string) {
-    return this.skillService.findOne(id);
+    return this.skillService.findOnePublic(id);
   }
 
   @Patch(':id')
@@ -85,5 +88,52 @@ export class SkillController {
   @ApiResponse({ status: 404, description: 'Skill not found' })
   remove(@Param('id') id: string) {
     return this.skillService.remove(id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Moderation endpoints (admin only)
+  // ---------------------------------------------------------------------------
+
+  @Get('pending')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'List all pending skills awaiting moderation (admin only)' })
+  @ApiResponse({ status: 200, description: 'List of pending skills' })
+  findPending() {
+    return this.skillService.findPending();
+  }
+
+  @Patch(':id/approve')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Approve a skill (admin only)' })
+  @ApiParam({ name: 'id', description: 'Skill UUID' })
+  @ApiResponse({ status: 200, description: 'Skill approved' })
+  @ApiResponse({ status: 400, description: 'Skill is already approved' })
+  @ApiResponse({ status: 404, description: 'Skill not found' })
+  approve(
+    @Param('id') id: string,
+    @Request() req: { user: { sub: string } },
+  ) {
+    return this.skillService.approve(id, req.user.sub);
+  }
+
+  @Patch(':id/reject')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Reject a skill (admin only)' })
+  @ApiParam({ name: 'id', description: 'Skill UUID' })
+  @ApiResponse({ status: 200, description: 'Skill rejected' })
+  @ApiResponse({ status: 400, description: 'Skill is already rejected' })
+  @ApiResponse({ status: 404, description: 'Skill not found' })
+  reject(
+    @Param('id') id: string,
+    @Body() dto: RejectSkillDto,
+    @Request() req: { user: { sub: string } },
+  ) {
+    return this.skillService.reject(id, req.user.sub, dto);
   }
 }


### PR DESCRIPTION
Add Skill Moderation Workflow
Summary
Implements a moderation workflow for skills with statuses: pending, approved, and rejected. This prevents spam/duplicates and ensures quality of the skill catalog.
Changes
New Files
src/common/enums/skill-status.enum.ts - Skill status enum
src/modules/skills/dto/reject-skill.dto.ts - Reject DTO with reason field
src/migration/1700000000001-AddSkillModerationFields.ts - Database migration
Modified Files
Both Skill entities - Added status, rejectionReason, moderatedBy, moderatedAt fields
SkillService (skills module) - Added moderation methods and status filtering
SkillController - Added moderation endpoints
SkillService (skill module) - Added status filtering to search/trending/recommendations
MentorSkillsService - Block non-approved skills from attachment


Closes #245 


