### PR TITLE
feat: user entity, user module, swagger docs, revoke-all (#361-364)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { SeedModule } from './database/seeds/seed.module';
 import { HealthModule } from './modules/health/health.module';
 import { RedisModule } from './redis/redis.module';
 import { AuthModule } from './modules/auth/auth.module';
+import { UserModule } from './modules/user/user.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { AuthModule } from './modules/auth/auth.module';
     SeedModule,
     RedisModule.forRoot(),
     AuthModule,
+    UserModule,
     HealthModule,
   ],
 })

--- a/src/database/migrations/1745493953000-ExpandUserEntity.ts
+++ b/src/database/migrations/1745493953000-ExpandUserEntity.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from 'typeorm';
+
+export class ExpandUserEntity1745493953000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('users', [
+      new TableColumn({ name: 'email', type: 'varchar', isNullable: true, isUnique: true }),
+      new TableColumn({ name: 'displayName', type: 'varchar', isNullable: true }),
+      new TableColumn({
+        name: 'status',
+        type: 'enum',
+        enum: ['active', 'pending', 'suspended', 'deleted'],
+        default: "'pending'",
+      }),
+      new TableColumn({ name: 'avatarUrl', type: 'varchar', isNullable: true }),
+      new TableColumn({ name: 'timezone', type: 'varchar', isNullable: true }),
+      new TableColumn({ name: 'locale', type: 'varchar', isNullable: true }),
+      new TableColumn({ name: 'lastLoginAt', type: 'timestamp', isNullable: true }),
+      new TableColumn({ name: 'deletedAt', type: 'timestamp', isNullable: true }),
+    ]);
+
+    await queryRunner.createIndex('users', new TableIndex({ name: 'IDX_USERS_EMAIL', columnNames: ['email'] }));
+    await queryRunner.createIndex('users', new TableIndex({ name: 'IDX_USERS_STATUS', columnNames: ['status'] }));
+    await queryRunner.createIndex('users', new TableIndex({ name: 'IDX_USERS_CREATED_AT', columnNames: ['createdAt'] }));
+    await queryRunner.createIndex('users', new TableIndex({ name: 'IDX_USERS_LAST_LOGIN_AT', columnNames: ['lastLoginAt'] }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('users', 'IDX_USERS_LAST_LOGIN_AT');
+    await queryRunner.dropIndex('users', 'IDX_USERS_CREATED_AT');
+    await queryRunner.dropIndex('users', 'IDX_USERS_STATUS');
+    await queryRunner.dropIndex('users', 'IDX_USERS_EMAIL');
+    await queryRunner.dropColumns('users', ['email', 'displayName', 'status', 'avatarUrl', 'timezone', 'locale', 'lastLoginAt', 'deletedAt']);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,11 @@ async function bootstrap() {
       .setTitle('SkillSync API')
       .setDescription('Enterprise-level API for SkillSync platform')
       .setVersion('1.0')
-      .addTag('api')
+      .addTag('Authentication')
+      .addTag('Wallet')
+      .addTag('Session Management')
+      .addTag('Users')
+      .addBearerAuth()
       .build();
 
     const document = SwaggerModule.createDocument(app, config);

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -3,10 +3,20 @@ import {
   Post,
   Get,
   Body,
+  Param,
   UseGuards,
   Headers,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { NonceDto } from './dto/nonce.dto';
 import { LoginDto } from './dto/login.dto';
@@ -14,23 +24,29 @@ import { RefreshDto } from './dto/refresh.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { CurrentUser } from './decorators/current-user.decorator';
 
-@ApiTags('auth')
+@ApiTags('Authentication')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('nonce')
-  @ApiOperation({ summary: 'Generate nonce for wallet authentication' })
-  @ApiResponse({ status: 200, description: 'Nonce generated successfully' })
+  @ApiTags('Wallet')
+  @ApiOperation({ summary: 'Request a nonce for wallet signature', description: 'Returns a one-time nonce to be signed by the wallet. Expires in 5 minutes.' })
+  @ApiBody({ type: NonceDto })
+  @ApiResponse({ status: 201, description: 'Nonce generated', schema: { example: { nonce: 'uuid-nonce' } } })
+  @ApiResponse({ status: 400, description: 'Invalid wallet address' })
   async generateNonce(@Body() nonceDto: NonceDto) {
     const nonce = await this.authService.generateNonce(nonceDto.walletAddress);
     return { nonce };
   }
 
   @Post('login')
-  @ApiOperation({ summary: 'Login with wallet signature' })
-  @ApiResponse({ status: 200, description: 'Login successful' })
-  @ApiResponse({ status: 401, description: 'Invalid credentials' })
+  @ApiTags('Wallet')
+  @ApiOperation({ summary: 'Authenticate with wallet signature', description: 'Verifies the signed nonce and returns JWT access + refresh tokens.' })
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({ status: 201, description: 'Login successful', schema: { example: { accessToken: 'eyJ...', refreshToken: 'eyJ...', user: { id: 'uuid', walletAddress: 'G...', roles: ['mentee'] } } } })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Invalid nonce or signature' })
   async login(
     @Body() loginDto: LoginDto,
     @Headers('user-agent') userAgent?: string,
@@ -40,9 +56,11 @@ export class AuthController {
   }
 
   @Post('refresh')
-  @ApiOperation({ summary: 'Refresh access token' })
-  @ApiResponse({ status: 200, description: 'Token refreshed successfully' })
-  @ApiResponse({ status: 401, description: 'Invalid refresh token' })
+  @ApiTags('Session Management')
+  @ApiOperation({ summary: 'Rotate refresh token', description: 'Exchanges a valid refresh token for a new access + refresh token pair (rotation).' })
+  @ApiBody({ type: RefreshDto })
+  @ApiResponse({ status: 201, description: 'Tokens refreshed', schema: { example: { accessToken: 'eyJ...', refreshToken: 'eyJ...' } } })
+  @ApiResponse({ status: 401, description: 'Invalid or expired refresh token' })
   async refresh(
     @Body() refreshDto: RefreshDto,
     @Headers('user-agent') userAgent?: string,
@@ -54,8 +72,10 @@ export class AuthController {
   @Post('logout')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Logout and invalidate token' })
-  @ApiResponse({ status: 200, description: 'Logout successful' })
+  @ApiTags('Session Management')
+  @ApiOperation({ summary: 'Logout current session', description: 'Blacklists the access token and revokes all refresh tokens for the current session.' })
+  @ApiResponse({ status: 201, description: 'Logout successful', schema: { example: { message: 'Logout successful' } } })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async logout(
     @CurrentUser() user: any,
     @Headers('authorization') authorization: string,
@@ -65,21 +85,24 @@ export class AuthController {
     return { message: 'Logout successful' };
   }
 
-  @Post('logout-all')
+  @Post('revoke-all')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Logout all sessions for current user' })
-  @ApiResponse({ status: 200, description: 'All sessions logged out' })
-  async logoutAll(@CurrentUser() user: any) {
-    await this.authService.logoutAll(user.userId);
-    return { message: 'All sessions logged out successfully' };
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Session Management')
+  @ApiOperation({ summary: 'Revoke all sessions', description: 'Invalidates all refresh tokens and increments token version, forcing re-authentication on all devices. Rate limited to 3 requests/hour.' })
+  @ApiResponse({ status: 200, description: 'All sessions revoked', schema: { example: { message: 'All sessions revoked', revokedCount: 3 } } })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
+  async revokeAll(@CurrentUser() user: any) {
+    return this.authService.revokeAll(user.userId);
   }
 
   @Get('profile')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get current user profile' })
-  @ApiResponse({ status: 200, description: 'User profile retrieved' })
+  @ApiResponse({ status: 200, description: 'Profile retrieved', schema: { example: { id: 'uuid', walletAddress: 'G...', roles: ['mentee'], permissions: ['read:profile'] } } })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getProfile(@CurrentUser() user: any) {
     return this.authService.getProfile(user.userId);
@@ -89,8 +112,10 @@ export class AuthController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Assign role to user (Admin only)' })
-  @ApiResponse({ status: 200, description: 'Role assigned successfully' })
-  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiBody({ schema: { example: { userId: 'uuid', roleName: 'mentor' } } })
+  @ApiResponse({ status: 201, description: 'Role assigned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — admin only' })
   async assignRole(
     @CurrentUser() user: any,
     @Body() body: { userId: string; roleName: string },
@@ -102,8 +127,10 @@ export class AuthController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Revoke role from user (Admin only)' })
-  @ApiResponse({ status: 200, description: 'Role revoked successfully' })
-  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiBody({ schema: { example: { userId: 'uuid', roleName: 'mentor' } } })
+  @ApiResponse({ status: 201, description: 'Role revoked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — admin only' })
   async revokeRole(
     @CurrentUser() user: any,
     @Body() body: { userId: string; roleName: string },

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   UnauthorizedException,
   ForbiddenException,
+  TooManyRequestsException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
@@ -16,6 +17,7 @@ import { RefreshDto } from './dto/refresh.dto';
 import { User, UserRole } from './entities/user.entity';
 import { Role } from './entities/role.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
+import { AuditLog, AuditEventType } from './entities/audit-log.entity';
 import { RedisService } from '../../redis/redis.service';
 import { normalizeWalletAddress } from '../../common/utils/wallet.utils';
 
@@ -48,6 +50,8 @@ export class AuthService {
     private roleRepository: Repository<Role>,
     @InjectRepository(RefreshToken)
     private refreshTokenRepository: Repository<RefreshToken>,
+    @InjectRepository(AuditLog)
+    private auditLogRepository: Repository<AuditLog>,
   ) {}
 
   /**
@@ -347,6 +351,54 @@ export class AuthService {
     await this.redisService.del(`${this.USER_SESSIONS_PREFIX}:${userId}`);
 
     this.logger.log(`All sessions logged out for user: ${userId}`);
+  }
+
+  /**
+   * Revoke all sessions (rate-limited: 3/hour per user)
+   */
+  async revokeAll(userId: string): Promise<{ message: string; revokedCount: number }> {
+    const rateLimitKey = `revoke-all:${userId}`;
+    const count = await this.redisService.incr(rateLimitKey);
+    if (count === 1) {
+      await this.redisService.expire(rateLimitKey, 3600);
+    }
+    if (count > 3) {
+      throw new TooManyRequestsException('Rate limit exceeded: 3 requests per hour');
+    }
+
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) throw new UnauthorizedException('User not found');
+
+    // Increment token version — invalidates all existing JWTs
+    user.tokenVersion += 1;
+    await this.userRepository.save(user);
+
+    // Revoke all refresh tokens and count them
+    const result = await this.refreshTokenRepository
+      .createQueryBuilder()
+      .update()
+      .set({ isRevoked: true })
+      .where('userId = :userId AND isRevoked = false', { userId })
+      .returning('id')
+      .execute();
+    const revokedCount = result.affected ?? 0;
+
+    // Clear Redis sessions
+    await this.redisService.del(`${this.USER_SESSIONS_PREFIX}:${userId}`);
+
+    // Audit log
+    await this.auditLogRepository.save(
+      this.auditLogRepository.create({
+        userId,
+        walletAddress: user.walletAddress,
+        eventType: AuditEventType.SESSIONS_REVOKED,
+        ipAddress: 'system',
+        metadata: { revokedCount },
+      }),
+    );
+
+    this.logger.log(`All sessions revoked for user: ${userId} (${revokedCount} tokens)`);
+    return { message: 'All sessions revoked', revokedCount };
   }
 
   /**

--- a/src/modules/auth/entities/audit-log.entity.ts
+++ b/src/modules/auth/entities/audit-log.entity.ts
@@ -20,6 +20,7 @@ export enum AuditEventType {
   PERMISSION_DENIED = 'permission_denied',
   ACCOUNT_LOCKED = 'account_locked',
   ACCOUNT_UNLOCKED = 'account_unlocked',
+  SESSIONS_REVOKED = 'sessions_revoked',
 }
 
 /**

--- a/src/modules/auth/entities/user.entity.ts
+++ b/src/modules/auth/entities/user.entity.ts
@@ -4,8 +4,10 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   ManyToMany,
   JoinTable,
+  Index,
 } from 'typeorm';
 import { Role } from './role.entity';
 
@@ -17,13 +19,43 @@ export enum UserRole {
   MENTEE = 'mentee',
 }
 
+export enum UserStatus {
+  ACTIVE = 'active',
+  PENDING = 'pending',
+  SUSPENDED = 'suspended',
+  DELETED = 'deleted',
+}
+
 @Entity('users')
+@Index(['status'])
+@Index(['createdAt'])
+@Index(['lastLoginAt'])
 export class User {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @Index({ unique: true })
   @Column({ unique: true })
   walletAddress: string;
+
+  @Index({ unique: true })
+  @Column({ unique: true, nullable: true })
+  email: string;
+
+  @Column({ nullable: true })
+  displayName: string;
+
+  @Column({ type: 'enum', enum: UserStatus, default: UserStatus.PENDING })
+  status: UserStatus;
+
+  @Column({ nullable: true })
+  avatarUrl: string;
+
+  @Column({ nullable: true })
+  timezone: string;
+
+  @Column({ nullable: true })
+  locale: string;
 
   @Column({ nullable: true })
   nonce: string;
@@ -31,17 +63,14 @@ export class User {
   @Column({ default: 1 })
   tokenVersion: number;
 
+  @Column({ type: 'timestamp', nullable: true })
+  lastLoginAt: Date;
+
   @ManyToMany(() => Role, (role) => role.users, { cascade: true })
   @JoinTable({
     name: 'user_roles',
-    joinColumn: {
-      name: 'userId',
-      referencedColumnName: 'id',
-    },
-    inverseJoinColumn: {
-      name: 'roleId',
-      referencedColumnName: 'id',
-    },
+    joinColumn: { name: 'userId', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'roleId', referencedColumnName: 'id' },
   })
   roles: Role[];
 
@@ -50,4 +79,7 @@ export class User {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date;
 }

--- a/src/modules/user/dto/update-user.dto.ts
+++ b/src/modules/user/dto/update-user.dto.ts
@@ -1,0 +1,30 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateUserDto {
+  @ApiPropertyOptional({ example: 'user@example.com' })
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @ApiPropertyOptional({ example: 'Alice' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  displayName?: string;
+
+  @ApiPropertyOptional({ example: 'https://cdn.example.com/avatar.png' })
+  @IsOptional()
+  @IsString()
+  avatarUrl?: string;
+
+  @ApiPropertyOptional({ example: 'America/New_York' })
+  @IsOptional()
+  @IsString()
+  timezone?: string;
+
+  @ApiPropertyOptional({ example: 'en-US' })
+  @IsOptional()
+  @IsString()
+  locale?: string;
+}

--- a/src/modules/user/dto/user-response.dto.ts
+++ b/src/modules/user/dto/user-response.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { UserStatus } from '../../auth/entities/user.entity';
+
+export class UserResponseDto {
+  @ApiProperty({ example: 'uuid' })
+  id: string;
+
+  @ApiProperty({ example: 'GBRPYHIL2CI3WHZDTOOQFC6EB4SJJSUM3ZULQ4XFJLROVYUCHARSE75' })
+  walletAddress: string;
+
+  @ApiPropertyOptional({ example: 'user@example.com' })
+  email?: string;
+
+  @ApiPropertyOptional({ example: 'Alice' })
+  displayName?: string;
+
+  @ApiProperty({ enum: UserStatus, example: UserStatus.ACTIVE })
+  status: UserStatus;
+
+  @ApiPropertyOptional({ example: 'https://cdn.example.com/avatar.png' })
+  avatarUrl?: string;
+
+  @ApiPropertyOptional({ example: 'America/New_York' })
+  timezone?: string;
+
+  @ApiPropertyOptional({ example: 'en-US' })
+  locale?: string;
+
+  @ApiProperty({ type: [String], example: ['mentee'] })
+  roles: string[];
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+
+  @ApiPropertyOptional()
+  lastLoginAt?: Date;
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Patch, Delete, Body, UseGuards, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { UserService } from './user.service';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { UserResponseDto } from './dto/user-response.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+
+@ApiTags('Users')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('users')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get own profile' })
+  @ApiResponse({ status: 200, type: UserResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  getMe(@CurrentUser() user: any): Promise<UserResponseDto> {
+    return this.userService.findById(user.userId);
+  }
+
+  @Patch('me')
+  @ApiOperation({ summary: 'Update own profile' })
+  @ApiResponse({ status: 200, type: UserResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  updateMe(@CurrentUser() user: any, @Body() dto: UpdateUserDto): Promise<UserResponseDto> {
+    return this.userService.update(user.userId, dto);
+  }
+
+  @Delete('me')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete own account (soft delete)' })
+  @ApiResponse({ status: 204, description: 'Account deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  deleteMe(@CurrentUser() user: any): Promise<void> {
+    return this.userService.remove(user.userId);
+  }
+}

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../auth/entities/user.entity';
+import { UserService } from './user.service';
+import { UserController } from './user.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User]), AuthModule],
+  controllers: [UserController],
+  providers: [UserService],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../auth/entities/user.entity';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { UserResponseDto } from './dto/user-response.dto';
+
+@Injectable()
+export class UserService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async findById(id: string): Promise<UserResponseDto> {
+    const user = await this.userRepository.findOne({ where: { id }, relations: ['roles'] });
+    if (!user) throw new NotFoundException('User not found');
+    return this.toResponse(user);
+  }
+
+  async update(id: string, dto: UpdateUserDto): Promise<UserResponseDto> {
+    const user = await this.userRepository.findOne({ where: { id }, relations: ['roles'] });
+    if (!user) throw new NotFoundException('User not found');
+    Object.assign(user, dto);
+    await this.userRepository.save(user);
+    return this.toResponse(user);
+  }
+
+  async remove(id: string): Promise<void> {
+    const user = await this.userRepository.findOne({ where: { id } });
+    if (!user) throw new NotFoundException('User not found');
+    await this.userRepository.softDelete(id);
+  }
+
+  private toResponse(user: User): UserResponseDto {
+    return {
+      id: user.id,
+      walletAddress: user.walletAddress,
+      email: user.email,
+      displayName: user.displayName,
+      status: user.status,
+      avatarUrl: user.avatarUrl,
+      timezone: user.timezone,
+      locale: user.locale,
+      roles: user.roles?.map((r) => r.name) ?? [],
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+      lastLoginAt: user.lastLoginAt,
+    };
+  }
+}


### PR DESCRIPTION

closes #361 
closes #362 
closes #363
closes #364

## Changes

**#364 — User entity + migration**
- Added `email`, `displayName`, `status` (enum: active/pending/suspended/deleted), `avatarUrl`, `timezone`, `locale`, `lastLoginAt`, `deletedAt` (soft delete)
- Indexes on `walletAddress`, `email`, `status`, `createdAt`, `lastLoginAt`
- Migration: `1745493953000-ExpandUserEntity`

**#363 — User module**
- `GET /users/me`, `PATCH /users/me`, `DELETE /users/me` (soft delete)
- `UserService` exported for use in other modules

**#362 — Swagger docs**
- All auth endpoints documented with request/response schemas and error codes (400/401/403/429)
- Bearer auth scheme added; tags: Authentication, Wallet, Session Management, Users

**#361 — POST /auth/revoke-all**
- Increments `tokenVersion` (invalidates all JWTs)
- Bulk-revokes all refresh tokens
- Redis rate limit: 3 requests/hour per user
- Audit log entry: `sessions_revoked`