### PR TITLE
feat: add verification badge service and timezone utility

### DIFF
--- a/src/common/utils/timezone.util.ts
+++ b/src/common/utils/timezone.util.ts
@@ -1,0 +1,72 @@
+// IANA timezone strings — a representative subset used for validation.
+const IANA_TIMEZONES = new Set([
+  'UTC',
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'America/Sao_Paulo',
+  'Europe/London',
+  'Europe/Paris',
+  'Europe/Berlin',
+  'Europe/Moscow',
+  'Asia/Dubai',
+  'Asia/Kolkata',
+  'Asia/Dhaka',
+  'Asia/Bangkok',
+  'Asia/Singapore',
+  'Asia/Tokyo',
+  'Asia/Seoul',
+  'Australia/Sydney',
+  'Pacific/Auckland',
+  'Africa/Lagos',
+  'Africa/Nairobi',
+  'Africa/Johannesburg',
+]);
+
+/**
+ * Returns true when the supplied string is a recognised IANA timezone identifier.
+ * Falls back to Intl.supportedValuesOf when available (Node 18+).
+ */
+export function isValidTimezone(tz: string): boolean {
+  if (typeof (Intl as any).supportedValuesOf === 'function') {
+    try {
+      return (Intl as any).supportedValuesOf('timeZone').includes(tz);
+    } catch {
+      // fall through
+    }
+  }
+  return IANA_TIMEZONES.has(tz);
+}
+
+/**
+ * Converts a UTC Date to a formatted ISO-8601 string in the given IANA timezone.
+ * Returns the UTC string unchanged if the timezone is invalid.
+ */
+export function toUserTimezone(utcDate: Date, timezone: string): string {
+  if (!isValidTimezone(timezone)) {
+    return utcDate.toISOString();
+  }
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(utcDate);
+}
+
+/**
+ * Extracts the user's preferred timezone from an Accept-Timezone header value,
+ * falling back to 'UTC' if the header is absent or invalid.
+ */
+export function resolveTimezone(
+  preferredTimezone?: string,
+  headerTimezone?: string,
+): string {
+  const tz = headerTimezone ?? preferredTimezone ?? 'UTC';
+  return isValidTimezone(tz) ? tz : 'UTC';
+}

--- a/src/modules/verification/verification.service.ts
+++ b/src/modules/verification/verification.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MentorProfile } from '../user/entities/mentor-profile.entity';
+
+export interface VerificationResult {
+  mentorId: string;
+  isVerified: boolean;
+  verifiedAt: Date | null;
+  verifiedByAdminId: string | null;
+  verificationNotes: string | null;
+}
+
+@Injectable()
+export class VerificationService {
+  constructor(
+    @InjectRepository(MentorProfile)
+    private readonly mentorProfileRepository: Repository<MentorProfile>,
+  ) {}
+
+  async verifyMentor(
+    mentorId: string,
+    adminId: string,
+    notes?: string,
+  ): Promise<VerificationResult> {
+    const profile = await this.mentorProfileRepository.findOne({
+      where: { id: mentorId },
+    });
+
+    if (!profile) {
+      throw new NotFoundException(`Mentor profile ${mentorId} not found`);
+    }
+
+    await this.mentorProfileRepository.update(mentorId, {
+      isVerified: true,
+      verifiedAt: new Date(),
+      verifiedByAdminId: adminId,
+      verificationNotes: notes ?? null,
+    } as Partial<MentorProfile>);
+
+    return {
+      mentorId,
+      isVerified: true,
+      verifiedAt: new Date(),
+      verifiedByAdminId: adminId,
+      verificationNotes: notes ?? null,
+    };
+  }
+
+  async revokeVerification(
+    mentorId: string,
+    adminId: string,
+  ): Promise<VerificationResult> {
+    const profile = await this.mentorProfileRepository.findOne({
+      where: { id: mentorId },
+    });
+
+    if (!profile) {
+      throw new NotFoundException(`Mentor profile ${mentorId} not found`);
+    }
+
+    await this.mentorProfileRepository.update(mentorId, {
+      isVerified: false,
+      verifiedAt: null,
+      verifiedByAdminId: adminId,
+      verificationNotes: null,
+    } as Partial<MentorProfile>);
+
+    return {
+      mentorId,
+      isVerified: false,
+      verifiedAt: null,
+      verifiedByAdminId: adminId,
+      verificationNotes: null,
+    };
+  }
+
+  async getVerificationStatus(mentorId: string): Promise<VerificationResult> {
+    const profile = await this.mentorProfileRepository.findOne({
+      where: { id: mentorId },
+    });
+
+    if (!profile) {
+      throw new NotFoundException(`Mentor profile ${mentorId} not found`);
+    }
+
+    return {
+      mentorId,
+      isVerified: (profile as any).isVerified ?? false,
+      verifiedAt: (profile as any).verifiedAt ?? null,
+      verifiedByAdminId: (profile as any).verifiedByAdminId ?? null,
+      verificationNotes: (profile as any).verificationNotes ?? null,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add `VerificationService` with `verifyMentor`, `revokeVerification`, and `getVerificationStatus` methods; each action records the acting admin ID, timestamp, and optional notes for audit purposes
- Add `timezone.util.ts` with IANA timezone validation, UTC-to-user-timezone conversion via `Intl.DateTimeFormat`, and a `resolveTimezone` helper that respects the `Accept-Timezone` header override

closes #373
closes #374