### PR TITLE
feat: availability calendar entities and portfolio link support

### DIFF
--- a/src/modules/availability/entities/availability.entity.ts
+++ b/src/modules/availability/entities/availability.entity.ts
@@ -1,0 +1,69 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('availability_slots')
+@Index(['mentorId'])
+export class AvailabilitySlot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  mentorId: string;
+
+  @Column({ type: 'int' })
+  dayOfWeek: number; // 0 = Sunday, 6 = Saturday
+
+  @Column({ type: 'time' })
+  startTime: string; // HH:MM in UTC
+
+  @Column({ type: 'time' })
+  endTime: string; // HH:MM in UTC
+
+  @Column({ default: 'UTC' })
+  timezone: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+@Entity('availability_exceptions')
+@Index(['mentorId'])
+export class AvailabilityException {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  mentorId: string;
+
+  @Column({ type: 'date' })
+  exceptionDate: string; // YYYY-MM-DD
+
+  @Column({ type: 'time', nullable: true })
+  startTime: string | null;
+
+  @Column({ type: 'time', nullable: true })
+  endTime: string | null;
+
+  @Column({ nullable: true })
+  reason: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/user/entities/portfolio-link.entity.ts
+++ b/src/modules/user/entities/portfolio-link.entity.ts
@@ -1,0 +1,77 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export type PortfolioPlatform =
+  | 'github'
+  | 'linkedin'
+  | 'twitter'
+  | 'website'
+  | 'behance'
+  | 'dribbble'
+  | 'medium'
+  | 'devto'
+  | 'youtube'
+  | 'other';
+
+@Entity('portfolio_links')
+@Index(['userId'])
+export class PortfolioLink {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  userId: string;
+
+  @Column()
+  url: string; // sanitized https URL
+
+  @Column({ type: 'varchar', default: 'other' })
+  platform: PortfolioPlatform;
+
+  @Column({ nullable: true })
+  displayTitle: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+export const MAX_PORTFOLIO_LINKS = 10;
+
+/** Detect platform from URL hostname. */
+export function detectPlatform(url: string): PortfolioPlatform {
+  try {
+    const { hostname } = new URL(url);
+    if (hostname.includes('github')) return 'github';
+    if (hostname.includes('linkedin')) return 'linkedin';
+    if (hostname.includes('twitter') || hostname.includes('x.com')) return 'twitter';
+    if (hostname.includes('behance')) return 'behance';
+    if (hostname.includes('dribbble')) return 'dribbble';
+    if (hostname.includes('medium')) return 'medium';
+    if (hostname.includes('dev.to')) return 'devto';
+    if (hostname.includes('youtube')) return 'youtube';
+    return 'website';
+  } catch {
+    return 'other';
+  }
+}
+
+/** Returns an error message if the URL is invalid, otherwise null. */
+export function validatePortfolioUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') return 'URL must use https.';
+    return null;
+  } catch {
+    return 'Invalid URL format.';
+  }
+}


### PR DESCRIPTION
Adds two new data models to support mentor availability scheduling and user portfolio links.

### Availability Calendar Model
Adds `AvailabilitySlot` and `AvailabilityException` TypeORM entities:
- `AvailabilitySlot` — weekly recurring slots (day of week 0–6, start/end time in UTC, timezone, active flag)
- `AvailabilityException` — one-off overrides for specific dates (vacation, holidays) with optional time window and reason
- Both entities are indexed on `mentorId` for query performance

### Portfolio Links Support
Adds `PortfolioLink` TypeORM entity with:
- `userId`, `url` (https-only), `platform`, `displayTitle` fields
- `detectPlatform(url)` — infers platform type (GitHub, LinkedIn, Twitter, Behance, etc.) from URL hostname
- `validatePortfolioUrl(url)` — enforces https and valid URL format
- `MAX_PORTFOLIO_LINKS = 10` constant for enforcement at the service layer
- Indexed on `userId` for performance

closes #371
closes #372