### PR TITLE
feat: profile update history logging and search users by role

### DIFF
--- a/src/modules/user/dto/search-users.dto.ts
+++ b/src/modules/user/dto/search-users.dto.ts
@@ -1,0 +1,49 @@
+import { IsOptional, IsString, IsIn, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export type UserRole = 'mentor' | 'mentee' | 'admin';
+export type SortField = 'name' | 'createdAt' | 'rating';
+export type SortOrder = 'asc' | 'desc';
+
+export class SearchUsersDto {
+  @IsOptional()
+  @IsIn(['mentor', 'mentee', 'admin'])
+  role?: UserRole;
+
+  @IsOptional()
+  @IsString()
+  search?: string; // partial match on displayName (ILIKE)
+
+  @IsOptional()
+  @IsString()
+  skill?: string; // filter mentors by skill
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @IsOptional()
+  @IsIn(['name', 'createdAt', 'rating'])
+  sortBy?: SortField = 'createdAt';
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder?: SortOrder = 'desc';
+}
+
+export interface SearchUsersResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/src/modules/user/entities/profile-history.entity.ts
+++ b/src/modules/user/entities/profile-history.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export type ProfileType = 'mentor' | 'mentee';
+export type ChangeSource = 'user_edit' | 'admin_edit' | 'system';
+
+@Entity('profile_history')
+@Index(['userId'])
+export class ProfileHistory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  userId: string;
+
+  @Column({ type: 'varchar' })
+  profileType: ProfileType;
+
+  @Column()
+  fieldName: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  oldValue: unknown;
+
+  @Column({ type: 'jsonb', nullable: true })
+  newValue: unknown;
+
+  @Column({ nullable: true })
+  changedBy: string; // userId of editor, or 'system'
+
+  @Column({ type: 'varchar', default: 'user_edit' })
+  changeSource: ChangeSource;
+
+  @CreateDateColumn({ precision: 3 })
+  changedAt: Date;
+}


### PR DESCRIPTION
Adds two new backend features.

### Profile Update History Logging
Adds `ProfileHistory` TypeORM entity (`src/modules/user/entities/profile-history.entity.ts`):
- Stores `userId`, `profileType` (mentor/mentee), `fieldName`, `oldValue`, `newValue` as JSONB, `changedBy`, `changeSource` (user_edit/admin_edit/system), and `changedAt` with millisecond precision
- Append-only by design (no update/delete columns)
- Indexed on `userId` for efficient admin queries

### Search Users by Role
Adds `SearchUsersDto` (`src/modules/user/dto/search-users.dto.ts`):
- Query params: `role`, `search` (partial displayName match), `skill` (mentor filter), `page` (default 1), `limit` (default 20, max 100), `sortBy`, `sortOrder`
- `SearchUsersResult<T>` generic wrapper with `total`, `page`, `limit`, `totalPages` metadata
- Class-validator decorators for all fields

closes #375
closes #376