### PR TITLE
feat(auth): nonce generation endpoint and Stellar wallet signature login

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -18,7 +18,6 @@ import {
   ApiBody,
 } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
-import { NonceDto } from './dto/nonce.dto';
 import { LoginDto } from './dto/login.dto';
 import { RefreshDto } from './dto/refresh.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
@@ -29,15 +28,19 @@ import { CurrentUser } from './decorators/current-user.decorator';
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  @Post('nonce')
+  @Get('nonce/:walletAddress')
   @ApiTags('Wallet')
   @ApiOperation({ summary: 'Request a nonce for wallet signature', description: 'Returns a one-time nonce to be signed by the wallet. Expires in 5 minutes.' })
-  @ApiBody({ type: NonceDto })
-  @ApiResponse({ status: 201, description: 'Nonce generated', schema: { example: { nonce: 'uuid-nonce' } } })
+  @ApiParam({
+    name: 'walletAddress',
+    description: 'Stellar wallet address (Ed25519 public key)',
+    example: 'GBRPYHIL2CI3WHZDTOOQFC6EB4SJJSUM3ZULQ4XFJLROVYUCHARSE75',
+  })
+  @ApiResponse({ status: 200, description: 'Nonce generated', schema: { example: { nonce: 'hex-or-base64-nonce', expiresAt: '2026-04-26T12:34:56.789Z' } } })
   @ApiResponse({ status: 400, description: 'Invalid wallet address' })
-  async generateNonce(@Body() nonceDto: NonceDto) {
-    const nonce = await this.authService.generateNonce(nonceDto.walletAddress);
-    return { nonce };
+  async generateNonce(@Param('walletAddress') walletAddress: string) {
+    const result = await this.authService.generateNonce(walletAddress);
+    return result;
   }
 
   @Post('login')

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -5,12 +5,13 @@ import {
   ForbiddenException,
   HttpException,
   HttpStatus,
+  BadRequestException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
-import { verifyMessage } from 'ethers';
+import * as StellarSdk from 'stellar-sdk';
 import { v4 as uuidv4 } from 'uuid';
 import * as crypto from 'crypto';
 import { LoginDto } from './dto/login.dto';
@@ -37,9 +38,13 @@ export interface JwtPayload {
 @Injectable()
 export class AuthService {
   private readonly logger = new Logger(AuthService.name);
-  private nonceStore = new Map<string, { nonce: string; expiresAt: number }>();
   private readonly TOKEN_BLACKLIST_PREFIX = 'blacklist:token';
   private readonly USER_SESSIONS_PREFIX = 'user:sessions';
+  private readonly NONCE_PREFIX = 'nonce';
+  private readonly NONCE_TTL_SECONDS = 300;
+  private readonly NONCE_RATE_LIMIT_PREFIX = 'nonce-generation';
+  private readonly LOGIN_RATE_LIMIT_PREFIX = 'login-attempts';
+
 
   constructor(
     private jwtService: JwtService,
@@ -58,20 +63,39 @@ export class AuthService {
   /**
    * Generate a nonce for wallet authentication
    */
-  async generateNonce(walletAddress: string): Promise<string> {
-    // Normalize wallet address for consistent storage and comparison
+  async generateNonce(walletAddress: string): Promise<{ nonce: string; expiresAt: string }> {
     const normalizedAddress = normalizeWalletAddress(walletAddress);
-    
-    const nonce = uuidv4();
-    
-    // Store nonce with 5 minute expiration using normalized address
-    this.nonceStore.set(normalizedAddress, {
-      nonce,
-      expiresAt: Date.now() + 300000, // 5 minutes
-    });
-    
-    this.logger.log(`Generated nonce for wallet: ${normalizedAddress}`);
-    return nonce;
+
+    const rateLimitKey = `${this.NONCE_RATE_LIMIT_PREFIX}:${normalizedAddress}`;
+    const count = await this.redisService.incr(rateLimitKey);
+    if (count === 1) {
+      await this.redisService.expire(rateLimitKey, 60);
+    }
+    if (count > 5) {
+      throw new HttpException(
+        'Rate limit exceeded: 5 requests per minute per wallet address',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    const nonce = crypto.randomBytes(32).toString('hex');
+    const nonceKey = `${this.NONCE_PREFIX}:${normalizedAddress}`;
+    await this.redisService.set(nonceKey, nonce, this.NONCE_TTL_SECONDS);
+
+    const expiresAt = new Date(Date.now() + this.NONCE_TTL_SECONDS * 1000).toISOString();
+
+    await this.auditLogRepository.save(
+      this.auditLogRepository.create({
+        walletAddress: normalizedAddress,
+        eventType: AuditEventType.NONCE_GENERATED,
+        ipAddress: 'system',
+        userAgent: null,
+        metadata: { expiresAt },
+      }),
+    );
+
+    this.logger.log(`Generated wallet nonce for: ${normalizedAddress}`);
+    return { nonce, expiresAt };
   }
 
   /**
@@ -83,21 +107,74 @@ export class AuthService {
     nonce: string,
   ): Promise<boolean> {
     try {
-      // Normalize wallet address for comparison
       const normalizedAddress = normalizeWalletAddress(walletAddress);
-      
-      // Reconstruct the message that was signed
       const message = `Sign this message to authenticate with SkillSync. Nonce: ${nonce}`;
-      
-      // Recover the address from the signature
-      const recoveredAddress = verifyMessage(message, signature);
-      
-      // Check if recovered address matches the normalized address
-      return recoveredAddress.toLowerCase() === normalizedAddress.toLowerCase();
+      const messageBuffer = Buffer.from(message, 'utf8');
+
+      const signatureBuffer = this.parseSignature(signature);
+      if (!signatureBuffer) {
+        return false;
+      }
+
+      const publicKeyBytes = StellarSdk.StrKey.decodeEd25519PublicKey(walletAddress);
+      const publicKey = StellarSdk.StrKey.encodeEd25519PublicKey(publicKeyBytes);
+      const keypair = StellarSdk.Keypair.fromPublicKey(publicKey);
+
+      const verified = keypair.verify(messageBuffer, signatureBuffer);
+      return verified;
     } catch (error) {
       this.logger.error('Signature verification failed', error);
       return false;
     }
+  }
+
+  private parseSignature(signature: string): Buffer | null {
+    const trimmed = signature.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const hex = trimmed.startsWith('0x') ? trimmed.slice(2) : trimmed;
+    if (/^[0-9a-fA-F]+$/.test(hex)) {
+      try {
+        return Buffer.from(hex, 'hex');
+      } catch {
+        return null;
+      }
+    }
+
+    try {
+      return Buffer.from(trimmed, 'base64');
+    } catch {
+      return null;
+    }
+  }
+
+  private async deleteNonce(normalizedAddress: string) {
+    await this.redisService.del(`${this.NONCE_PREFIX}:${normalizedAddress}`);
+  }
+
+  private async recordLoginAttempt(
+    walletAddress: string,
+    success: boolean,
+    userAgent?: string,
+    ipAddress?: string,
+    errorMessage?: string,
+    userId?: string,
+  ) {
+    await this.auditLogRepository.save(
+      this.auditLogRepository.create({
+        walletAddress,
+        userId,
+        eventType: success
+          ? AuditEventType.LOGIN_SUCCESS
+          : AuditEventType.LOGIN_FAILED,
+        ipAddress: ipAddress || 'unknown',
+        userAgent: userAgent || null,
+        errorMessage: errorMessage || null,
+        metadata: { success },
+      }),
+    );
   }
 
   /**
@@ -105,38 +182,60 @@ export class AuthService {
    */
   async login(loginDto: LoginDto, userAgent?: string, ipAddress?: string) {
     const { walletAddress, signature, nonce } = loginDto;
-
-    // Normalize wallet address for consistent storage and comparison
     const normalizedAddress = normalizeWalletAddress(walletAddress);
 
-    // Verify nonce
-    const storedNonceData = this.nonceStore.get(normalizedAddress);
+    const rateLimitKey = `${this.LOGIN_RATE_LIMIT_PREFIX}:${normalizedAddress}`;
+    const attempts = await this.redisService.incr(rateLimitKey);
+    if (attempts === 1) {
+      await this.redisService.expire(rateLimitKey, 900);
+    }
+    if (attempts > 10) {
+      await this.recordLoginAttempt(
+        normalizedAddress,
+        false,
+        userAgent,
+        ipAddress,
+        'Rate limit exceeded',
+      );
+      throw new HttpException(
+        'Rate limit exceeded: 10 attempts per 15 minutes per wallet',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
 
-    if (!storedNonceData || storedNonceData.nonce !== nonce) {
+    const nonceKey = `${this.NONCE_PREFIX}:${normalizedAddress}`;
+    const storedNonce = await this.redisService.get(nonceKey);
+    if (!storedNonce || storedNonce !== nonce) {
+      await this.deleteNonce(normalizedAddress);
+      await this.recordLoginAttempt(
+        normalizedAddress,
+        false,
+        userAgent,
+        ipAddress,
+        'Invalid or expired nonce',
+      );
       throw new UnauthorizedException('Invalid or expired nonce');
     }
 
-    // Check if nonce is expired
-    if (Date.now() > storedNonceData.expiresAt) {
-      this.nonceStore.delete(normalizedAddress);
-      throw new UnauthorizedException('Nonce expired');
-    }
-
-    // Verify signature
     const isValidSignature = await this.verifySignature(
-      normalizedAddress,
+      walletAddress,
       signature,
       nonce,
     );
 
+    await this.deleteNonce(normalizedAddress);
+
     if (!isValidSignature) {
+      await this.recordLoginAttempt(
+        normalizedAddress,
+        false,
+        userAgent,
+        ipAddress,
+        'Invalid signature',
+      );
       throw new UnauthorizedException('Invalid signature');
     }
 
-    // Delete used nonce
-    this.nonceStore.delete(normalizedAddress);
-
-    // Find or create user (include soft-deleted for reactivation check)
     let user = await this.userRepository.findOne({
       where: { walletAddress: normalizedAddress },
       relations: ['roles'],
@@ -144,12 +243,17 @@ export class AuthService {
     });
 
     if (user && user.deletedAt) {
-      // Soft-deleted user attempting to log in
       if (user.gracePeriodEndsAt && user.gracePeriodEndsAt > new Date()) {
-        // Within grace period — reactivate account
         await this.reactivateUser(user);
       } else {
-        // Grace period expired — account permanently deleted
+        await this.recordLoginAttempt(
+          normalizedAddress,
+          false,
+          userAgent,
+          ipAddress,
+          'Account permanently deleted',
+          user.id,
+        );
         throw new UnauthorizedException(
           'Account has been permanently deleted. Please contact support to create a new account.',
         );
@@ -162,7 +266,6 @@ export class AuthService {
         tokenVersion: 1,
       });
 
-      // Assign default mentee role
       let menteeRole = await this.roleRepository.findOne({
         where: { name: UserRole.MENTEE },
       });
@@ -179,14 +282,13 @@ export class AuthService {
       await this.userRepository.save(user);
     }
 
-    // Get user roles and permissions
+    user.lastLoginAt = new Date();
+    await this.userRepository.save(user);
+
     const roles = user.roles.map((role) => role.name);
     const permissions = this.getPermissionsForRoles(roles);
 
-    // Generate JWT tokens
     const tokens = await this.generateTokens(user, roles, permissions);
-
-    // Store refresh token in database
     const deviceFingerprint = this.generateDeviceFingerprint(
       normalizedAddress,
       userAgent,
@@ -206,7 +308,15 @@ export class AuthService {
       ),
     });
 
-    // Audit log
+    await this.recordLoginAttempt(
+      normalizedAddress,
+      true,
+      userAgent,
+      ipAddress,
+      null,
+      user.id,
+    );
+
     this.logger.log(`User logged in: ${normalizedAddress}`);
 
     return {
@@ -215,8 +325,8 @@ export class AuthService {
       user: {
         id: user.id,
         walletAddress: user.walletAddress,
-        roles: roles,
-        permissions: permissions,
+        roles,
+        permissions,
       },
     };
   }

--- a/src/modules/auth/tests/auth.service.spec.ts
+++ b/src/modules/auth/tests/auth.service.spec.ts
@@ -1,10 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { UnauthorizedException } from '@nestjs/common';
+import { RedisService } from '../../../redis/redis.service';
 import { AuthService } from '../auth.service';
 import { LoginDto } from '../dto/login.dto';
 import { RefreshDto } from '../dto/refresh.dto';
+import { User } from '../entities/user.entity';
+import { Role } from '../entities/role.entity';
+import { RefreshToken } from '../entities/refresh-token.entity';
+import { AuditLog } from '../entities/audit-log.entity';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -14,6 +20,7 @@ describe('AuthService', () => {
   const mockJwtService = {
     sign: jest.fn().mockReturnValue('mock-jwt-token'),
     verify: jest.fn(),
+    decode: jest.fn().mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 3600 }),
   };
 
   const mockConfigService = {
@@ -28,6 +35,34 @@ describe('AuthService', () => {
     }),
   };
 
+  const mockRedisService = {
+    incr: jest.fn().mockResolvedValue(1),
+    expire: jest.fn().mockResolvedValue(true),
+    set: jest.fn().mockResolvedValue(undefined),
+    get: jest.fn().mockResolvedValue(null),
+    del: jest.fn().mockResolvedValue(0),
+    exists: jest.fn().mockResolvedValue(false),
+  };
+
+  const createMockRepository = () => ({
+    findOne: jest.fn(),
+    create: jest.fn((dto) => dto),
+    save: jest.fn().mockResolvedValue({}),
+    update: jest.fn().mockResolvedValue({}),
+    createQueryBuilder: jest.fn().mockReturnValue({
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      returning: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue({ affected: 0 }),
+    }),
+  });
+
+  const mockUserRepository = createMockRepository();
+  const mockRoleRepository = createMockRepository();
+  const mockRefreshTokenRepository = createMockRepository();
+  const mockAuditLogRepository = createMockRepository();
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -39,6 +74,26 @@ describe('AuthService', () => {
         {
           provide: ConfigService,
           useValue: mockConfigService,
+        },
+        {
+          provide: RedisService,
+          useValue: mockRedisService,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
+        },
+        {
+          provide: getRepositoryToken(Role),
+          useValue: mockRoleRepository,
+        },
+        {
+          provide: getRepositoryToken(RefreshToken),
+          useValue: mockRefreshTokenRepository,
+        },
+        {
+          provide: getRepositoryToken(AuditLog),
+          useValue: mockAuditLogRepository,
         },
       ],
     }).compile();
@@ -89,17 +144,19 @@ describe('AuthService', () => {
     });
 
     it('should login successfully with valid credentials', async () => {
-      // First generate a nonce
-      const walletAddress = '0x1234567890123456789012345678901234567890';
-      const nonce = await service.generateNonce(walletAddress);
+      const walletAddress = 'GBRPYHIL2CI3WHZDTOOQFC6EB4SJJSUM3ZULQ4XFJLROVYUCHARSE75';
+      const nonceResult = await service.generateNonce(walletAddress);
 
-      // Mock signature verification to return true
+      mockRedisService.get.mockResolvedValueOnce(nonceResult.nonce);
       jest.spyOn(service, 'verifySignature').mockResolvedValue(true);
+      mockRoleRepository.findOne.mockResolvedValueOnce(null);
+      mockRoleRepository.create.mockImplementation((dto) => ({ ...dto, id: 'role-id' }));
+      mockRoleRepository.save.mockResolvedValueOnce({ id: 'role-id', name: 'mentee' });
 
       const loginDto: LoginDto = {
         walletAddress,
         signature: '0xsignature',
-        nonce,
+        nonce: nonceResult.nonce,
       };
 
       const result = await service.login(loginDto);
@@ -107,7 +164,7 @@ describe('AuthService', () => {
       expect(result).toHaveProperty('accessToken');
       expect(result).toHaveProperty('refreshToken');
       expect(result).toHaveProperty('user');
-      expect(result.user.walletAddress).toBe(walletAddress);
+      expect(result.user.walletAddress).toBe(walletAddress.toLowerCase());
     });
   });
 
@@ -133,9 +190,27 @@ describe('AuthService', () => {
 
       mockJwtService.verify.mockReturnValue({
         sub: 'user-id',
-        walletAddress: '0x1234567890123456789012345678901234567890',
-        role: 'user',
+        walletAddress: 'GBRPYHIL2CI3WHZDTOOQFC6EB4SJJSUM3ZULQ4XFJLROVYUCHARSE75',
+        roles: ['mentee'],
+        permissions: [],
         type: 'refresh',
+      });
+
+      mockRedisService.exists.mockResolvedValue(false);
+      mockRefreshTokenRepository.findOne.mockResolvedValueOnce({
+        token: 'valid-refresh-token',
+        isRevoked: false,
+        expiresAt: new Date(Date.now() + 100000),
+        createdAt: new Date(Date.now() - 2000),
+        userId: 'user-id',
+        user: {
+          id: 'user-id',
+          walletAddress: 'gbrpyhil2ci3whzdtooqfc6eb4sjjsum3zulq4xfj1abc',
+          roles: [{ name: 'mentee' }],
+        },
+        deviceFingerprint: 'fingerprint',
+        userAgent: 'test-agent',
+        ipAddress: '127.0.0.1',
       });
 
       const result = await service.refreshTokens(refreshDto);
@@ -158,16 +233,27 @@ describe('AuthService', () => {
     it('should validate token payload', async () => {
       const payload = {
         sub: 'user-id',
-        walletAddress: '0x1234567890123456789012345678901234567890',
-        role: 'user',
+        walletAddress: 'GBRPYHIL2CI3WHZDTOOQFC6EB4SJJSUM3ZULQ4XFJLROVYUCHARSE75',
+        roles: ['mentee'],
+        permissions: [],
+        jti: 'test-jti',
+        tokenVersion: 1,
       };
 
-      const result = await service.validateToken(payload);
+      mockUserRepository.findOne.mockResolvedValueOnce({
+        id: 'user-id',
+        walletAddress: payload.walletAddress.toLowerCase(),
+        tokenVersion: 1,
+        roles: [{ name: 'mentee' }],
+      });
+
+      const result = await service.validateToken(payload as any);
 
       expect(result).toEqual({
         userId: payload.sub,
-        walletAddress: payload.walletAddress,
-        role: payload.role,
+        walletAddress: payload.walletAddress.toLowerCase(),
+        roles: ['mentee'],
+        permissions: [],
       });
     });
   });
@@ -176,11 +262,19 @@ describe('AuthService', () => {
     it('should return user profile', async () => {
       const userId = 'user-id';
 
+      mockUserRepository.findOne.mockResolvedValueOnce({
+        id: userId,
+        walletAddress: 'gbrpyhil2ci3whzdtooqfc6eb4sjjsum3zulq4xfjlrovyucharse75',
+        roles: [{ name: 'mentee' }],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
       const result = await service.getProfile(userId);
 
       expect(result).toHaveProperty('id', userId);
       expect(result).toHaveProperty('walletAddress');
-      expect(result).toHaveProperty('role');
+      expect(result).toHaveProperty('roles');
     });
   });
 });


### PR DESCRIPTION
 Summary
Implements wallet-based authentication for MentoNest/SkillSync_Server —
nonce generation with Redis TTL and Stellar signature verification login.

## Changes

### #348 — Nonce Generation Endpoint
- **Route:** \`GET /auth/nonce/:walletAddress\`
- Response: \`{ nonce: string, expiresAt: ISOString }\`
- Redis key: \`nonce:{walletAddress}\` with 5-minute TTL
- Stellar wallet address format validated on request
- New nonce invalidates previous unused nonce for same wallet
- \`crypto.randomBytes(32)\` for cryptographic randomness
- Rate limit: 5 requests per minute per wallet

### #349 — Stellar Wallet Signature Verification Login
- **Route:** \`POST /auth/login\`
- Accepts: \`walletAddress\`, \`nonce\`, \`signature\`
- Verifies signature via Stellar SDK \`StrKey\` and \`verify\` methods
- Nonce expiration checked before verification attempt
- Used nonce deleted from Redis immediately after any attempt
- Invalid signature → \`401 Unauthorized\` with clear message
- Success → user created or retrieved + access + refresh tokens returned
- Mainnet and testnet wallet address support
- Rate limit: 10 attempts per 15 minutes per wallet
- Audit log entry written for every attempt — success and failure

## Test Coverage
- [ ] Nonce: unique per request, Redis TTL set, previous nonce invalidated
- [ ] Nonce: invalid Stellar address rejected, rate limit enforced
- [ ] Login: valid signature succeeds, returns tokens
- [ ] Login: invalid signature returns 401
- [ ] Login: expired nonce rejected before verification
- [ ] Login: nonce deleted from Redis after attempt (success and failure)
- [ ] Login: rate limit blocks after 10 attempts per 15 minutes
- [ ] Login: audit log written on success and failure

## Closes
Closes #348
Closes #349