### PR TITLE
feat: reusable pagination utility service

### DIFF
--- a/src/modules/pagination/pagination.service.spec.ts
+++ b/src/modules/pagination/pagination.service.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { PaginationService } from './pagination.service';
+
+const makeQb = (rows: any[], total?: number) => ({
+  skip: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  getManyAndCount: jest.fn().mockResolvedValue([rows, total ?? rows.length]),
+  getMany: jest.fn().mockResolvedValue(rows),
+});
+
+const makeRepo = (rows: any[], total?: number) => ({
+  findAndCount: jest.fn().mockResolvedValue([rows, total ?? rows.length]),
+});
+
+describe('PaginationService', () => {
+  let service: PaginationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PaginationService],
+    }).compile();
+    service = module.get<PaginationService>(PaginationService);
+  });
+
+  describe('paginate', () => {
+    it('returns paginated response with correct meta', async () => {
+      const rows = [{ id: 1 }, { id: 2 }];
+      const qb = makeQb(rows, 10) as any;
+
+      const result = await service.paginate(qb, 2, 2);
+
+      expect(result.data).toEqual(rows);
+      expect(result.meta.page).toBe(2);
+      expect(result.meta.limit).toBe(2);
+      expect(result.meta.total).toBe(10);
+      expect(result.meta.totalPages).toBe(5);
+      expect(result.meta.hasNext).toBe(true);
+      expect(result.meta.hasPrev).toBe(true);
+    });
+
+    it('clamps page to minimum 1', async () => {
+      const qb = makeQb([], 0) as any;
+      const result = await service.paginate(qb, -5, 10);
+      expect(result.meta.page).toBe(1);
+    });
+
+    it('enforces max limit of 100', async () => {
+      const qb = makeQb([], 0) as any;
+      const result = await service.paginate(qb, 1, 9999);
+      expect(result.meta.limit).toBe(100);
+    });
+
+    it('hasNext is false on last page', async () => {
+      const qb = makeQb([{ id: 1 }], 1) as any;
+      const result = await service.paginate(qb, 1, 10);
+      expect(result.meta.hasNext).toBe(false);
+      expect(result.meta.hasPrev).toBe(false);
+    });
+
+    it('page beyond total still returns valid meta', async () => {
+      const qb = makeQb([], 5) as any;
+      const result = await service.paginate(qb, 100, 10);
+      expect(result.meta.page).toBe(100);
+      expect(result.meta.hasNext).toBe(false);
+    });
+  });
+
+  describe('paginateRepository', () => {
+    it('calls findAndCount with correct skip/take', async () => {
+      const rows = [{ id: 1 }];
+      const repo = makeRepo(rows, 30) as any;
+
+      const result = await service.paginateRepository(repo, 3, 10);
+
+      expect(repo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 20, take: 10 }),
+      );
+      expect(result.meta.page).toBe(3);
+    });
+  });
+
+  describe('cursor pagination', () => {
+    it('encodes and decodes cursor round-trip', () => {
+      const encoded = service.encodeCursor('42');
+      expect(service.decodeCursor(encoded)).toBe('42');
+    });
+
+    it('throws BadRequestException for invalid cursor', () => {
+      // non-base64 input that would fail to decode meaningfully
+      expect(() => service.decodeCursor('!!invalid!!')).toThrow(BadRequestException);
+    });
+
+    it('returns nextCursor when more rows exist', async () => {
+      const rows = [{ id: 1 }, { id: 2 }, { id: 3 }]; // limit=2, hasMore
+      const qb = makeQb(rows) as any;
+
+      const result = await service.cursorPaginate(qb, 2);
+
+      expect(result.data).toHaveLength(2);
+      expect(result.nextCursor).not.toBeNull();
+    });
+
+    it('returns null nextCursor on last page', async () => {
+      const rows = [{ id: 1 }]; // limit=2, no more
+      const qb = makeQb(rows) as any;
+
+      const result = await service.cursorPaginate(qb, 2);
+
+      expect(result.nextCursor).toBeNull();
+    });
+  });
+});

--- a/src/modules/pagination/pagination.service.ts
+++ b/src/modules/pagination/pagination.service.ts
@@ -1,24 +1,169 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { SelectQueryBuilder, Repository, FindManyOptions } from 'typeorm';
+
+/** Default and maximum allowed page sizes */
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  meta: PaginationMeta;
+}
+
+export interface CursorPage<T> {
+  data: T[];
+  nextCursor: string | null;
+  prevCursor: string | null;
+  limit: number;
+}
+
+export interface PaginateOptions {
+  /** Override the default column used for ordering (default: 'id') */
+  orderBy?: string;
+  orderDirection?: 'ASC' | 'DESC';
+}
 
 @Injectable()
 export class PaginationService {
-  create() {
-    return 'This action adds a new pagination';
+  /**
+   * Offset/limit pagination against a TypeORM QueryBuilder.
+   *
+   * @param queryBuilder  - must NOT already have skip/take applied
+   * @param page          - 1-indexed page number (default 1)
+   * @param limit         - items per page (default 20, max 100)
+   */
+  async paginate<T>(
+    queryBuilder: SelectQueryBuilder<T>,
+    page = 1,
+    limit = DEFAULT_LIMIT,
+    options: PaginateOptions = {},
+  ): Promise<PaginatedResponse<T>> {
+    const safePage = Math.max(1, Math.floor(page));
+    const safeLimit = Math.min(Math.max(1, Math.floor(limit)), MAX_LIMIT);
+
+    const [data, total] = await queryBuilder
+      .skip((safePage - 1) * safeLimit)
+      .take(safeLimit)
+      .getManyAndCount();
+
+    return this.buildResponse(data, total, safePage, safeLimit);
   }
 
-  findAll() {
-    return `This action returns all pagination`;
+  /**
+   * Offset/limit pagination against a TypeORM Repository.
+   */
+  async paginateRepository<T>(
+    repo: Repository<T>,
+    page = 1,
+    limit = DEFAULT_LIMIT,
+    findOptions: FindManyOptions<T> = {},
+  ): Promise<PaginatedResponse<T>> {
+    const safePage = Math.max(1, Math.floor(page));
+    const safeLimit = Math.min(Math.max(1, Math.floor(limit)), MAX_LIMIT);
+
+    const [data, total] = await repo.findAndCount({
+      ...findOptions,
+      skip: (safePage - 1) * safeLimit,
+      take: safeLimit,
+    });
+
+    return this.buildResponse(data, total, safePage, safeLimit);
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} pagination`;
+  /**
+   * Cursor-based pagination for high-performance scenarios.
+   *
+   * Cursors are opaque base64-encoded strings containing the cursor column value.
+   * The `cursorColumn` should be indexed (e.g. `id`, `createdAt`).
+   *
+   * @param queryBuilder  - base query, must NOT have where/order/skip/take for cursor fields
+   * @param limit         - items per page (max 100)
+   * @param afterCursor   - fetch items after this cursor (forward pagination)
+   * @param beforeCursor  - fetch items before this cursor (backward pagination)
+   * @param cursorColumn  - column name to use as cursor (default: 'id')
+   * @param alias         - QueryBuilder alias (default: 'entity')
+   */
+  async cursorPaginate<T extends Record<string, any>>(
+    queryBuilder: SelectQueryBuilder<T>,
+    limit = DEFAULT_LIMIT,
+    afterCursor?: string,
+    beforeCursor?: string,
+    cursorColumn = 'id',
+    alias = 'entity',
+  ): Promise<CursorPage<T>> {
+    const safeLimit = Math.min(Math.max(1, Math.floor(limit)), MAX_LIMIT);
+
+    const decodedAfter = afterCursor ? this.decodeCursor(afterCursor) : null;
+    const decodedBefore = beforeCursor ? this.decodeCursor(beforeCursor) : null;
+
+    if (decodedAfter) {
+      queryBuilder.andWhere(`${alias}.${cursorColumn} > :after`, { after: decodedAfter });
+    }
+
+    if (decodedBefore) {
+      queryBuilder.andWhere(`${alias}.${cursorColumn} < :before`, { before: decodedBefore });
+    }
+
+    queryBuilder.orderBy(`${alias}.${cursorColumn}`, 'ASC').take(safeLimit + 1);
+
+    const rows = await queryBuilder.getMany();
+
+    const hasMore = rows.length > safeLimit;
+    const data = hasMore ? rows.slice(0, safeLimit) : rows;
+
+    const nextCursor =
+      hasMore && data.length > 0
+        ? this.encodeCursor(String(data[data.length - 1][cursorColumn]))
+        : null;
+
+    const prevCursor =
+      decodedAfter && data.length > 0
+        ? this.encodeCursor(String(data[0][cursorColumn]))
+        : null;
+
+    return { data, nextCursor, prevCursor, limit: safeLimit };
   }
 
-  update(id: number) {
-    return `This action updates a #${id} pagination`;
+  /** Encode a cursor value to an opaque base64 string */
+  encodeCursor(value: string): string {
+    return Buffer.from(value).toString('base64');
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} pagination`;
+  /** Decode an opaque base64 cursor back to its raw value */
+  decodeCursor(cursor: string): string {
+    try {
+      return Buffer.from(cursor, 'base64').toString('utf-8');
+    } catch {
+      throw new BadRequestException('Invalid cursor value');
+    }
+  }
+
+  private buildResponse<T>(
+    data: T[],
+    total: number,
+    page: number,
+    limit: number,
+  ): PaginatedResponse<T> {
+    const totalPages = Math.ceil(total / limit) || 1;
+    return {
+      data,
+      meta: {
+        page,
+        limit,
+        total,
+        totalPages,
+        hasNext: page < totalPages,
+        hasPrev: page > 1,
+      },
+    };
   }
 }


### PR DESCRIPTION
## Summary

- Implements `PaginationService.paginate(queryBuilder, page, limit)` applying `skip`/`take` automatically
- Implements `paginateRepository` for `Repository`-based queries
- Implements `cursorPaginate` for high-performance cursor-based pagination (opaque base64 cursors, `afterCursor`/`beforeCursor`)
- `PaginatedResponse<T>` includes `data` + `meta: { page, limit, total, totalPages, hasNext, hasPrev }`
- Max limit enforced at 100 (configurable); page clamped to ≥ 1

## Test plan

- [ ] `paginate(qb, 2, 5)` → correct `skip=5`, `take=5`, `page=2`
- [ ] `limit=9999` → clamped to 100
- [ ] `page=-1` → treated as page 1
- [ ] Page beyond total → `hasNext=false`
- [ ] Cursor encode/decode round-trip
- [ ] Invalid cursor → `BadRequestException`

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)