### PR TITLE
feat: common API response formatter with standardized envelope

### DIFF
--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -1,29 +1,73 @@
-import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus } from '@nestjs/common';
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
 import { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+
+export interface ApiErrorResponse {
+  success: false;
+  statusCode: number;
+  error: string;
+  message: string | string[];
+  timestamp: string;
+  path: string;
+  requestId: string;
+}
 
 @Catch()
 export class HttpExceptionFilter implements ExceptionFilter {
-  catch(exception: unknown, host: ArgumentsHost) {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
     const isHttpException = exception instanceof HttpException;
 
-    const status = isHttpException ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+    const status = isHttpException
+      ? exception.getStatus()
+      : HttpStatus.INTERNAL_SERVER_ERROR;
 
     const exceptionResponse = isHttpException ? exception.getResponse() : null;
 
-    const message =
-      typeof exceptionResponse === 'string'
-        ? exceptionResponse
-        : (exceptionResponse as any)?.message || 'Internal server error';
+    let message: string | string[] = 'Internal server error';
+    let error = 'Internal Server Error';
 
-    response.status(status).json({
+    if (typeof exceptionResponse === 'string') {
+      message = exceptionResponse;
+    } else if (typeof exceptionResponse === 'object' && exceptionResponse !== null) {
+      const r = exceptionResponse as Record<string, unknown>;
+      message = (r.message as string | string[]) ?? message;
+      error = (r.error as string) ?? error;
+    }
+
+    const requestId: string =
+      (request.headers['x-request-id'] as string | undefined) ?? randomUUID();
+    response.setHeader('x-request-id', requestId);
+
+    if (status >= 500) {
+      this.logger.error(
+        `${request.method} ${request.url} → ${status}`,
+        exception instanceof Error ? exception.stack : String(exception),
+      );
+    }
+
+    const body: ApiErrorResponse = {
+      success: false,
       statusCode: status,
+      error,
       message,
       timestamp: new Date().toISOString(),
       path: request.url,
-    });
+      requestId,
+    };
+
+    response.status(status).json(body);
   }
 }

--- a/src/common/interceptors/transform.interceptor.spec.ts
+++ b/src/common/interceptors/transform.interceptor.spec.ts
@@ -1,0 +1,56 @@
+import { TransformInterceptor } from './transform.interceptor';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+
+function makeContext(overrides: Record<string, unknown> = {}): ExecutionContext {
+  const req = { url: '/test', headers: {}, ...overrides };
+  const res = { statusCode: 200, setHeader: jest.fn() };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => req,
+      getResponse: () => res,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('TransformInterceptor', () => {
+  let interceptor: TransformInterceptor<unknown>;
+
+  beforeEach(() => {
+    interceptor = new TransformInterceptor();
+  });
+
+  it('wraps data in success envelope', async () => {
+    const ctx = makeContext();
+    const handler: CallHandler = { handle: () => of({ id: 1 }) };
+
+    const result = await firstValueFrom(interceptor.intercept(ctx, handler));
+
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.data).toEqual({ id: 1 });
+    expect(result.message).toBe('OK');
+    expect(result.path).toBe('/test');
+    expect(result.requestId).toBeTruthy();
+    expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('uses x-request-id header if present', async () => {
+    const ctx = makeContext({ headers: { 'x-request-id': 'trace-abc' } });
+    const handler: CallHandler = { handle: () => of({}) };
+
+    const result = await firstValueFrom(interceptor.intercept(ctx, handler));
+    expect(result.requestId).toBe('trace-abc');
+  });
+
+  it('generates unique requestId when header absent', async () => {
+    const ctx1 = makeContext();
+    const ctx2 = makeContext();
+    const handler: CallHandler = { handle: () => of({}) };
+
+    const r1 = await firstValueFrom(interceptor.intercept(ctx1, handler));
+    const r2 = await firstValueFrom(interceptor.intercept(ctx2, handler));
+    expect(r1.requestId).not.toBe(r2.requestId);
+  });
+});

--- a/src/common/interceptors/transform.interceptor.ts
+++ b/src/common/interceptors/transform.interceptor.ts
@@ -1,19 +1,50 @@
-import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { Request, Response as ExpressResponse } from 'express';
+import { randomUUID } from 'crypto';
 
-export interface Response<T> {
-  success: boolean;
+export interface ApiSuccessResponse<T> {
+  success: true;
+  statusCode: number;
+  message: string;
   data: T;
+  timestamp: string;
+  path: string;
+  requestId: string;
 }
 
 @Injectable()
-export class TransformInterceptor<T> implements NestInterceptor<T, Response<T>> {
-  intercept(context: ExecutionContext, next: CallHandler): Observable<Response<T>> {
+export class TransformInterceptor<T>
+  implements NestInterceptor<T, ApiSuccessResponse<T>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<ApiSuccessResponse<T>> {
+    const http = context.switchToHttp();
+    const req = http.getRequest<Request>();
+    const res = http.getResponse<ExpressResponse>();
+
+    // Attach a requestId for tracing; re-use one already set by upstream middleware
+    const requestId: string =
+      (req.headers['x-request-id'] as string | undefined) ?? randomUUID();
+    res.setHeader('x-request-id', requestId);
+
     return next.handle().pipe(
       map((data) => ({
-        success: true,
+        success: true as const,
+        statusCode: res.statusCode,
+        message: 'OK',
         data,
+        timestamp: new Date().toISOString(),
+        path: req.url,
+        requestId,
       })),
     );
   }


### PR DESCRIPTION
## Summary

- Updates `TransformInterceptor` to emit full success envelope: `{ success, statusCode, message, data, timestamp, path, requestId }`
- Updates `HttpExceptionFilter` to emit error envelope: `{ success: false, statusCode, error, message, timestamp, path, requestId }`
- `requestId` sourced from `X-Request-Id` request header or generated via `crypto.randomUUID()`
- `requestId` echoed in `X-Request-Id` response header for distributed tracing
- 500+ errors logged via NestJS `Logger` for audit visibility

## Test plan

- [ ] All `2xx` responses include `success: true`, `statusCode`, `data`, `timestamp`, `path`, `requestId`
- [ ] All error responses include `success: false`, `statusCode`, `error`, `message`
- [ ] `X-Request-Id` header on request is forwarded to response
- [ ] Missing `X-Request-Id` generates a unique UUID
- [ ] Unit tests verify structure, header forwarding, unique ID generation

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)