### PR TITLE
feat: DTO validation with custom validators across all modules

### DIFF
--- a/src/common/dto/date-range-query.dto.ts
+++ b/src/common/dto/date-range-query.dto.ts
@@ -1,0 +1,16 @@
+import { IsOptional, IsDateString } from 'class-validator';
+import { IsAfterDate } from '../validators/is-after-date.validator';
+
+/**
+ * Reusable date range filter — extend or compose with other DTOs.
+ */
+export class DateRangeQueryDto {
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @IsAfterDate('startDate')
+  endDate?: string;
+}

--- a/src/common/dto/pagination-query.dto.ts
+++ b/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,21 @@
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * Base DTO for any paginated list endpoint.
+ * Extend this class and add endpoint-specific filters.
+ */
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/common/validators/is-after-date.validator.ts
+++ b/src/common/validators/is-after-date.validator.ts
@@ -1,0 +1,58 @@
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  registerDecorator,
+  ValidationOptions,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'IsAfterDate', async: false })
+export class IsAfterDateConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    const [referenceProperty] = args.constraints as [string];
+    const object = args.object as Record<string, unknown>;
+    const referenceDate = object[referenceProperty];
+
+    if (!value || !referenceDate) return true; // let @IsDate handle presence
+
+    const valueDate = new Date(value as string);
+    const refDate = new Date(referenceDate as string);
+
+    if (isNaN(valueDate.getTime()) || isNaN(refDate.getTime())) return false;
+
+    return valueDate > refDate;
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const [referenceProperty] = args.constraints as [string];
+    return `$property must be after ${referenceProperty}`;
+  }
+}
+
+/**
+ * Validates that a date field comes after another date field on the same DTO.
+ *
+ * @param property  - the property name to compare against
+ *
+ * @example
+ * class Dto {
+ *   @IsDateString()
+ *   startDate: string;
+ *
+ *   @IsDateString()
+ *   @IsAfterDate('startDate')
+ *   endDate: string;
+ * }
+ */
+export function IsAfterDate(property: string, options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'IsAfterDate',
+      target: object.constructor,
+      propertyName,
+      options,
+      constraints: [property],
+      validator: IsAfterDateConstraint,
+    });
+  };
+}

--- a/src/common/validators/is-stellar-address.validator.ts
+++ b/src/common/validators/is-stellar-address.validator.ts
@@ -1,0 +1,47 @@
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  registerDecorator,
+  ValidationOptions,
+} from 'class-validator';
+
+/**
+ * Stellar public key (G…) or contract address (C…):
+ * - Starts with G or C
+ * - 56 base32 characters (A-Z, 2-7)
+ */
+const STELLAR_ADDRESS_REGEX = /^[GC][A-Z2-7]{55}$/;
+
+@ValidatorConstraint({ name: 'IsStellarAddress', async: false })
+export class IsStellarAddressConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, _args: ValidationArguments): boolean {
+    return typeof value === 'string' && STELLAR_ADDRESS_REGEX.test(value);
+  }
+
+  defaultMessage(_args: ValidationArguments): string {
+    return '$property must be a valid Stellar public key or contract address';
+  }
+}
+
+/**
+ * Validates that a string is a valid Stellar public key (G…) or contract address (C…).
+ *
+ * @example
+ * class Dto {
+ *   @IsStellarAddress()
+ *   walletAddress: string;
+ * }
+ */
+export function IsStellarAddress(options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'IsStellarAddress',
+      target: object.constructor,
+      propertyName,
+      options,
+      constraints: [],
+      validator: IsStellarAddressConstraint,
+    });
+  };
+}

--- a/src/common/validators/validators.spec.ts
+++ b/src/common/validators/validators.spec.ts
@@ -1,0 +1,92 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { IsString } from 'class-validator';
+import { IsStellarAddress } from './is-stellar-address.validator';
+import { IsAfterDate } from './is-after-date.validator';
+import { PaginationQueryDto } from '../dto/pagination-query.dto';
+import { DateRangeQueryDto } from '../dto/date-range-query.dto';
+
+// ─── IsStellarAddress ────────────────────────────────────────────────────────
+
+class AddressDto {
+  @IsStellarAddress()
+  address: string;
+}
+
+describe('IsStellarAddress', () => {
+  const valid = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+
+  it('accepts a valid G-address', async () => {
+    const dto = plainToInstance(AddressDto, { address: valid });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects an address shorter than 56 chars', async () => {
+    const dto = plainToInstance(AddressDto, { address: 'GABC' });
+    const errors = await validate(dto);
+    expect(errors[0].constraints?.IsStellarAddress).toBeTruthy();
+  });
+
+  it('rejects a non-G/C prefix', async () => {
+    const dto = plainToInstance(AddressDto, { address: valid.replace('G', 'X') });
+    const errors = await validate(dto);
+    expect(errors[0].constraints?.IsStellarAddress).toBeTruthy();
+  });
+
+  it('rejects a random string', async () => {
+    const dto = plainToInstance(AddressDto, { address: 'not-an-address' });
+    const errors = await validate(dto);
+    expect(errors).not.toHaveLength(0);
+  });
+});
+
+// ─── IsAfterDate ─────────────────────────────────────────────────────────────
+
+describe('IsAfterDate', () => {
+  it('passes when endDate is after startDate', async () => {
+    const dto = plainToInstance(DateRangeQueryDto, {
+      startDate: '2025-01-01',
+      endDate: '2025-12-31',
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('fails when endDate is before startDate', async () => {
+    const dto = plainToInstance(DateRangeQueryDto, {
+      startDate: '2025-12-31',
+      endDate: '2025-01-01',
+    });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'endDate')).toBe(true);
+  });
+
+  it('passes when only startDate is provided', async () => {
+    const dto = plainToInstance(DateRangeQueryDto, { startDate: '2025-01-01' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+// ─── PaginationQueryDto ───────────────────────────────────────────────────────
+
+describe('PaginationQueryDto', () => {
+  it('defaults page=1 limit=20', () => {
+    const dto = plainToInstance(PaginationQueryDto, {});
+    expect(dto.page).toBe(1);
+    expect(dto.limit).toBe(20);
+  });
+
+  it('rejects limit > 100', async () => {
+    const dto = plainToInstance(PaginationQueryDto, { limit: 999 });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('rejects negative page', async () => {
+    const dto = plainToInstance(PaginationQueryDto, { page: -1 });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Global `ValidationPipe` already configured in `main.ts` with `whitelist: true`, `forbidNonWhitelisted: true`, `transform: true`
- Adds `@IsStellarAddress()` — validates Stellar G/C public keys (56-char base32, correct prefix)
- Adds `@IsAfterDate(property)` — cross-field date validation (e.g., `endDate` must be after `startDate`)
- Adds `PaginationQueryDto` base class for reuse across all list endpoints
- Adds `DateRangeQueryDto` composing `@IsDateString` + `@IsAfterDate`

## Test plan

- [ ] Valid Stellar address passes; wrong prefix/length fails with readable message
- [ ] `endDate` before `startDate` returns validation error on `endDate`
- [ ] `PaginationQueryDto` with `limit=999` fails with max=100 error
- [ ] DTO with extra unlisted fields is stripped (whitelist) or rejected (forbidNonWhitelisted)
- [ ] All validation errors return 400 with user-friendly messages

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)