### PR TITLE
feat: standardize API response envelopes

### DIFF
--- a/src/common/filters/global-exception.filter.spec.ts
+++ b/src/common/filters/global-exception.filter.spec.ts
@@ -44,6 +44,7 @@ describe('GlobalExceptionFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
       expect(mockResponse.json).toHaveBeenCalledWith(
         expect.objectContaining({
+          success: false,
           statusCode: HttpStatus.BAD_REQUEST,
           message: 'Bad request',
           error: 'Bad Request',
@@ -61,6 +62,7 @@ describe('GlobalExceptionFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
       expect(mockResponse.json).toHaveBeenCalledWith(
         expect.objectContaining({
+          success: false,
           statusCode: HttpStatus.NOT_FOUND,
           message: 'Not found',
           error: 'Not Found',
@@ -77,6 +79,7 @@ describe('GlobalExceptionFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.UNAUTHORIZED);
       expect(mockResponse.json).toHaveBeenCalledWith(
         expect.objectContaining({
+          success: false,
           statusCode: HttpStatus.UNAUTHORIZED,
           message: 'Unauthorized',
           error: 'Unauthorized',
@@ -93,6 +96,7 @@ describe('GlobalExceptionFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.FORBIDDEN);
       expect(mockResponse.json).toHaveBeenCalledWith(
         expect.objectContaining({
+          success: false,
           statusCode: HttpStatus.FORBIDDEN,
           message: 'Forbidden',
           error: 'Forbidden',
@@ -115,6 +119,7 @@ describe('GlobalExceptionFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
       expect(mockResponse.json).toHaveBeenCalledWith(
         expect.objectContaining({
+          success: false,
           statusCode: HttpStatus.CONFLICT,
           message: 'Custom business error',
           errorCode: ErrorCodes.CONFLICT,
@@ -134,6 +139,7 @@ describe('GlobalExceptionFilter', () => {
       );
       expect(mockResponse.json).toHaveBeenCalledWith(
         expect.objectContaining({
+          success: false,
           statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
           message: 'Internal server error',
           error: 'Internal Server Error',
@@ -229,6 +235,7 @@ describe('GlobalExceptionFilter', () => {
       const response = mockResponse.json.mock.calls[0][0];
 
       expect(response).toHaveProperty('statusCode');
+      expect(response).toHaveProperty('success', false);
       expect(response).toHaveProperty('message');
       expect(response).toHaveProperty('error');
       expect(response).toHaveProperty('errorCode');

--- a/src/common/filters/global-exception.filter.ts
+++ b/src/common/filters/global-exception.filter.ts
@@ -9,17 +9,11 @@ import {
 import { Request, Response } from 'express';
 import { BusinessException } from '../exceptions/business.exception';
 import { ErrorCodes } from '../exceptions/error-codes.enum';
-
-export interface ErrorResponse {
-  statusCode: number;
-  message: string | string[];
-  error: string;
-  errorCode?: ErrorCodes;
-  timestamp: string;
-  path: string;
-  requestId?: string;
-  stack?: string;
-}
+import {
+  buildErrorResponse,
+  ErrorResponse,
+  ValidationFieldMessage,
+} from '../utils/api-response.util';
 
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
@@ -67,15 +61,12 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const status = exception.getStatus();
     const exceptionResponse = exception.getResponse() as any;
 
-    return {
+    return buildErrorResponse(request, {
       statusCode: status,
       message: exceptionResponse.message || exception.message,
       error: exception.name,
       errorCode: exception.getErrorCode(),
-      timestamp: new Date().toISOString(),
-      path: request.url,
-      requestId: this.getRequestId(request),
-    };
+    });
   }
 
   private handleHttpException(
@@ -92,15 +83,12 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       message = this.formatValidationErrors(exceptionResponse.message);
     }
 
-    return {
+    return buildErrorResponse(request, {
       statusCode: status,
       message,
       error: exceptionResponse.error || this.getErrorName(status),
       errorCode: this.mapStatusCodeToErrorCode(status),
-      timestamp: new Date().toISOString(),
-      path: request.url,
-      requestId: this.getRequestId(request),
-    };
+    });
   }
 
   private handleUnknownException(
@@ -109,21 +97,15 @@ export class GlobalExceptionFilter implements ExceptionFilter {
   ): ErrorResponse {
     this.logger.error('Unhandled exception caught', exception);
 
-    return {
+    return buildErrorResponse(request, {
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
       message: 'Internal server error',
       error: 'Internal Server Error',
       errorCode: ErrorCodes.INTERNAL_ERROR,
-      timestamp: new Date().toISOString(),
-      path: request.url,
-      requestId: this.getRequestId(request),
-    };
+    });
   }
 
-  private formatValidationErrors(errors: string[]): Array<{
-    field: string;
-    errors: string[];
-  }> {
+  private formatValidationErrors(errors: string[]): ValidationFieldMessage[] {
     return errors.map((error) => {
       // Expected format: "property should not be null" or "property must be an email"
       const match = error.match(/^(\w+)\s+(.+)$/);
@@ -166,10 +148,6 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     };
 
     return errorNames[status] || 'Error';
-  }
-
-  private getRequestId(request: Request): string | undefined {
-    return request.headers['x-request-id'] as string;
   }
 
   private logError(

--- a/src/common/interceptors/api-response.interceptor.spec.ts
+++ b/src/common/interceptors/api-response.interceptor.spec.ts
@@ -1,0 +1,153 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { lastValueFrom, of } from 'rxjs';
+import { ApiResponseInterceptor } from './api-response.interceptor';
+
+describe('ApiResponseInterceptor', () => {
+  let interceptor: ApiResponseInterceptor<unknown>;
+
+  beforeEach(() => {
+    interceptor = new ApiResponseInterceptor();
+  });
+
+  const createHttpContext = (options: {
+    method: string;
+    url: string;
+    statusCode: number;
+    requestId?: string;
+  }): ExecutionContext =>
+    ({
+      getType: () => 'http',
+      switchToHttp: () => ({
+        getRequest: () => ({
+          method: options.method,
+          url: options.url,
+          originalUrl: options.url,
+          headers: options.requestId
+            ? { 'x-request-id': options.requestId }
+            : {},
+        }),
+        getResponse: () => ({
+          statusCode: options.statusCode,
+        }),
+      }),
+    }) as ExecutionContext;
+
+  const createHandler = (body: unknown): CallHandler => ({
+    handle: () => of(body),
+  });
+
+  it('wraps successful controller responses in the standard envelope', async () => {
+    const response = await lastValueFrom(
+      interceptor.intercept(
+        createHttpContext({
+          method: 'GET',
+          url: '/users/me',
+          statusCode: 200,
+          requestId: 'req-plain',
+        }),
+        createHandler({ ok: true }),
+      ),
+    );
+
+    expect(response).toMatchObject({
+      success: true,
+      statusCode: 200,
+      message: 'Request successful',
+      data: { ok: true },
+      path: '/users/me',
+      requestId: 'req-plain',
+    });
+    expect(typeof response.timestamp).toBe('string');
+  });
+
+  it('keeps pagination metadata inside the data field for list controller responses', async () => {
+    const response = await lastValueFrom(
+      interceptor.intercept(
+        createHttpContext({
+          method: 'GET',
+          url: '/users',
+          statusCode: 200,
+          requestId: 'req-list',
+        }),
+        createHandler({
+          data: [{ id: 1 }],
+          meta: {
+            page: 1,
+            limit: 10,
+            total: 1,
+            totalPages: 1,
+            hasNext: false,
+            hasPrev: false,
+          },
+        }),
+      ),
+    );
+
+    expect(response).toMatchObject({
+      success: true,
+      statusCode: 200,
+      message: 'Request successful',
+      data: {
+        data: [{ id: 1 }],
+        meta: {
+          page: 1,
+          limit: 10,
+          total: 1,
+          totalPages: 1,
+          hasNext: false,
+          hasPrev: false,
+        },
+      },
+      requestId: 'req-list',
+    });
+  });
+
+  it('uses controller-provided messages when available', async () => {
+    const response = await lastValueFrom(
+      interceptor.intercept(
+        createHttpContext({
+          method: 'POST',
+          url: '/users',
+          statusCode: 201,
+          requestId: 'req-create',
+        }),
+        createHandler({
+          message: 'User created successfully',
+          data: { id: 'user-1' },
+        }),
+      ),
+    );
+
+    expect(response).toMatchObject({
+      success: true,
+      statusCode: 201,
+      message: 'User created successfully',
+      data: { id: 'user-1' },
+      requestId: 'req-create',
+    });
+  });
+
+  it('normalizes message-only controller responses to null data', async () => {
+    const response = await lastValueFrom(
+      interceptor.intercept(
+        createHttpContext({
+          method: 'POST',
+          url: '/auth/logout',
+          statusCode: 201,
+          requestId: 'req-logout',
+        }),
+        createHandler({
+          message: 'Logout successful',
+        }),
+      ),
+    );
+
+    expect(response).toMatchObject({
+      success: true,
+      statusCode: 201,
+      message: 'Logout successful',
+      data: null,
+      requestId: 'req-logout',
+    });
+  });
+});

--- a/src/common/interceptors/api-response.interceptor.ts
+++ b/src/common/interceptors/api-response.interceptor.ts
@@ -1,0 +1,91 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { buildSuccessResponse, SuccessResponse } from '../utils/api-response.util';
+
+@Injectable()
+export class ApiResponseInterceptor<T> implements NestInterceptor<T, SuccessResponse<unknown>> {
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<SuccessResponse<unknown>> {
+    if (context.getType() !== 'http') {
+      return next.handle() as Observable<SuccessResponse<unknown>>;
+    }
+
+    const http = context.switchToHttp();
+    const request = http.getRequest<Request>();
+    const response = http.getResponse<Response>();
+    const defaultMessage = this.getDefaultMessage(request.method, response.statusCode);
+
+    return next.handle().pipe(
+      map((body) => {
+        const normalized = this.normalizeBody(body, defaultMessage);
+
+        return buildSuccessResponse(
+          request,
+          response.statusCode,
+          normalized.message,
+          normalized.data,
+        );
+      }),
+    );
+  }
+
+  private normalizeBody(
+    body: T,
+    defaultMessage: string,
+  ): {
+    message: string;
+    data: unknown;
+  } {
+    if (
+      body &&
+      typeof body === 'object' &&
+      !Array.isArray(body) &&
+      'message' in body &&
+      typeof body.message === 'string'
+    ) {
+      const { message, ...rest } = body as Record<string, unknown> & {
+        message: string;
+      };
+
+      if (Object.keys(rest).length === 0) {
+        return { message, data: null };
+      }
+
+      if ('data' in rest && Object.keys(rest).length === 1) {
+        return { message, data: rest.data };
+      }
+
+      return { message, data: rest };
+    }
+
+    return {
+      message: defaultMessage,
+      data: body,
+    };
+  }
+
+  private getDefaultMessage(method: string, statusCode: number): string {
+    if (statusCode === 201 || method === 'POST') {
+      return 'Resource created successfully';
+    }
+
+    if (method === 'PUT' || method === 'PATCH') {
+      return 'Request completed successfully';
+    }
+
+    if (method === 'DELETE') {
+      return 'Resource deleted successfully';
+    }
+
+    return 'Request successful';
+  }
+}

--- a/src/common/utils/api-response.util.ts
+++ b/src/common/utils/api-response.util.ts
@@ -1,0 +1,79 @@
+import { Request } from 'express';
+import { ErrorCodes } from '../exceptions/error-codes.enum';
+
+export interface ValidationFieldMessage {
+  field: string;
+  errors: string[];
+}
+
+export type ResponseMessage = string | string[] | ValidationFieldMessage[];
+
+export interface SuccessResponse<T> {
+  success: true;
+  statusCode: number;
+  message: string;
+  data: T;
+  timestamp: string;
+  path: string;
+  requestId?: string;
+}
+
+export interface ErrorResponse {
+  success: false;
+  statusCode: number;
+  message: ResponseMessage;
+  error: string;
+  errorCode?: ErrorCodes;
+  timestamp: string;
+  path: string;
+  requestId?: string;
+  stack?: string;
+}
+
+export function getRequestId(request: Request): string | undefined {
+  return request.headers['x-request-id'] as string | undefined;
+}
+
+export function getRequestPath(request: Request): string {
+  return request.originalUrl || request.url;
+}
+
+export function buildSuccessResponse<T>(
+  request: Request,
+  statusCode: number,
+  message: string,
+  data: T,
+): SuccessResponse<T> {
+  return {
+    success: true,
+    statusCode,
+    message,
+    data,
+    timestamp: new Date().toISOString(),
+    path: getRequestPath(request),
+    requestId: getRequestId(request),
+  };
+}
+
+export function buildErrorResponse(
+  request: Request,
+  payload: {
+    statusCode: number;
+    error: string;
+    message: ResponseMessage;
+    errorCode?: ErrorCodes;
+    stack?: string;
+  },
+): ErrorResponse {
+  return {
+    success: false,
+    statusCode: payload.statusCode,
+    message: payload.message,
+    error: payload.error,
+    errorCode: payload.errorCode,
+    timestamp: new Date().toISOString(),
+    path: getRequestPath(request),
+    requestId: getRequestId(request),
+    stack: payload.stack,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { ValidationPipe, Logger } from '@nestjs/common';
+import { ValidationPipe, Logger, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import * as compression from 'compression';
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
 import { RequestLoggerMiddleware } from './common/middleware/request-logger.middleware';
+import { ApiResponseInterceptor } from './common/interceptors/api-response.interceptor';
 import { DataSource } from 'typeorm';
 import { AdminSeedService } from './database/seeds/admin-seed.service';
 
@@ -34,8 +35,8 @@ async function bootstrap() {
   // Global exception filter
   app.useGlobalFilters(new GlobalExceptionFilter());
 
-  // Global logging interceptor (removed in favor of structured request logger middleware)
-  // app.useGlobalInterceptors(new LoggingInterceptor());
+  // Global response envelope
+  app.useGlobalInterceptors(new ApiResponseInterceptor());
 
   // Global validation pipe with custom error formatting
   app.useGlobalPipes(
@@ -47,13 +48,17 @@ async function bootstrap() {
         enableImplicitConversion: true,
       },
       exceptionFactory: (errors) => {
-        const messages = errors.map((error) => {
+        const messages = errors.flatMap((error) => {
           const constraints = error.constraints
             ? Object.values(error.constraints)
             : [];
-          return `${error.property} ${constraints.join(', ')}`;
+          return constraints.map((message) => `${error.property} ${message}`);
         });
-        return new Error(messages.join(', '));
+
+        return new BadRequestException({
+          message: messages,
+          error: 'Bad Request',
+        });
       },
     }),
   );


### PR DESCRIPTION
## Summary
- add a global success interceptor that wraps controller responses with status, message, timestamp, path, and request ID
- refactor the global exception filter onto the same envelope helper and keep validation failures as 400 responses
- add focused response-envelope tests for success and error structures

## Testing
- npm test -- global-exception.filter.spec.ts api-response.interceptor.spec.ts --runInBand
- npm run build (currently blocked by existing upstream dependency and missing-file errors outside this branch)

Fixes #385