### PR TITLE
462 Refresh token support

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,8 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import { AppDataSource } from './database/data-source';
 import { HttpLoggerMiddleware } from './common/middleware/http-logger.middleware';
-import { ConfigModule } from '@nestjs/config';
-import { AppController } from './app.controller';
+import { AuthModule } from './auth/auth.module';
 import { RedisModule } from './redis/redis.module';
 import { HealthModule } from './health/health.module';
 
@@ -17,6 +16,7 @@ import { HealthModule } from './health/health.module';
       ...AppDataSource.options,
       retryAttempts: 5,
     }),
+    AuthModule,
     RedisModule,
     HealthModule,
   ],

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Post,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { AuthService } from './auth.service';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('refresh')
+  @HttpCode(200)
+  refresh(@Body() body: RefreshTokenDto, @Req() request: Request) {
+    if (!body?.refreshToken || typeof body.refreshToken !== 'string') {
+      throw new UnauthorizedException('Refresh token is required');
+    }
+
+    return this.authService.refresh(body.refreshToken, {
+      ipAddress: this.getIpAddress(request),
+      userAgent: request.headers['user-agent'] ?? null,
+      deviceFingerprint: this.getDeviceFingerprint(request),
+    });
+  }
+
+  private getIpAddress(request: Request): string | null {
+    const forwardedFor = request.headers['x-forwarded-for'];
+    if (typeof forwardedFor === 'string' && forwardedFor.length > 0) {
+      return forwardedFor.split(',')[0].trim();
+    }
+
+    return request.socket.remoteAddress ?? null;
+  }
+
+  private getDeviceFingerprint(request: Request): string | null {
+    const header = request.headers['x-device-fingerprint'];
+    return typeof header === 'string' && header.length > 0 ? header : null;
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { RefreshToken } from './entities/refresh-token.entity';
+
+@Module({
+  imports: [ConfigModule, TypeOrmModule.forFeature([RefreshToken])],
+  controllers: [AuthController],
+  providers: [AuthService],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,155 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, IsNull } from 'typeorm';
+import { AuthService } from './auth.service';
+import { RefreshToken } from './entities/refresh-token.entity';
+
+class InMemoryRefreshTokenRepository {
+  tokens: RefreshToken[] = [];
+
+  create(data: Partial<RefreshToken>): RefreshToken {
+    return Object.assign(new RefreshToken(), data);
+  }
+
+  async save(token: RefreshToken): Promise<RefreshToken> {
+    token.setIds();
+    const existingIndex = this.tokens.findIndex((item) => item.id === token.id);
+    if (existingIndex >= 0) {
+      this.tokens[existingIndex] = token;
+    } else {
+      this.tokens.push(token);
+    }
+
+    return token;
+  }
+}
+
+class InMemoryEntityManager {
+  constructor(private readonly repository: InMemoryRefreshTokenRepository) {}
+
+  async findOne(
+    _entity: typeof RefreshToken,
+    options: { where: { tokenHash: string } },
+  ): Promise<RefreshToken | null> {
+    return this.repository.tokens.find((token) => token.tokenHash === options.where.tokenHash) ?? null;
+  }
+
+  async save(_entity: typeof RefreshToken, token: RefreshToken): Promise<RefreshToken> {
+    return this.repository.save(token);
+  }
+
+  async update(
+    _entity: typeof RefreshToken,
+    where: { familyId: string; revokedAt: ReturnType<typeof IsNull> },
+    values: Partial<RefreshToken>,
+  ): Promise<void> {
+    for (const token of this.repository.tokens) {
+      if (token.familyId === where.familyId && token.revokedAt === null) {
+        Object.assign(token, values);
+      }
+    }
+  }
+}
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let repository: InMemoryRefreshTokenRepository;
+  const config: Record<string, string> = {
+    JWT_SECRET: 'test-secret',
+    REFRESH_TOKEN_HASH_SECRET: 'hash-secret',
+    JWT_ACCESS_TOKEN_TTL: '15m',
+    JWT_REFRESH_TOKEN_TTL: '30d',
+  };
+
+  beforeEach(async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    repository = new InMemoryRefreshTokenRepository();
+    const manager = new InMemoryEntityManager(repository);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: getRepositoryToken(RefreshToken),
+          useValue: repository,
+        },
+        {
+          provide: DataSource,
+          useValue: {
+            transaction: (
+              handler: (entityManager: InMemoryEntityManager) => Promise<unknown>,
+            ) => handler(manager),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => config[key],
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(AuthService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('rotates refresh tokens and invalidates the previous token', async () => {
+    const issued = await service.issueTokenPair(
+      { sub: 'user-1', walletAddress: 'GABC' },
+      audit(),
+    );
+    const rotated = await service.refresh(
+      issued.refreshToken,
+      audit({ ipAddress: '10.0.0.2' }),
+    );
+
+    expect(rotated.accessToken).toBeDefined();
+    expect(rotated.refreshToken).not.toBe(issued.refreshToken);
+    expect(repository.tokens).toHaveLength(2);
+    expect(repository.tokens[0].revokedAt).toBeInstanceOf(Date);
+    expect(repository.tokens[0].replacedByTokenId).toBe(repository.tokens[1].id);
+    expect(repository.tokens[1].revokedAt).toBeNull();
+    expect(repository.tokens[1].ipAddress).toBe('10.0.0.2');
+  });
+
+  it('returns 401 when the refresh token is expired', async () => {
+    const issued = await service.issueTokenPair({ sub: 'user-1' }, audit());
+    jest.setSystemTime(new Date('2026-02-01T00:00:01.000Z'));
+
+    await expect(service.refresh(issued.refreshToken, audit())).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('detects refresh token reuse and revokes the token family', async () => {
+    const issued = await service.issueTokenPair({ sub: 'user-1' }, audit());
+    await service.refresh(issued.refreshToken, audit());
+
+    await expect(service.refresh(issued.refreshToken, audit())).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+
+    expect(repository.tokens.every((token) => token.revokedAt)).toBe(true);
+    expect(repository.tokens.every((token) => token.concurrentReuseDetectedAt)).toBe(true);
+  });
+});
+
+function audit(
+  overrides: Partial<{
+    ipAddress: string;
+    userAgent: string;
+    deviceFingerprint: string;
+  }> = {},
+) {
+  return {
+    ipAddress: overrides.ipAddress ?? '127.0.0.1',
+    userAgent: overrides.userAgent ?? 'jest',
+    deviceFingerprint: overrides.deviceFingerprint ?? 'device-1',
+  };
+}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,308 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { createHmac, randomUUID, timingSafeEqual } from 'crypto';
+import { DataSource, EntityManager, IsNull, Repository } from 'typeorm';
+import { RefreshToken } from './entities/refresh-token.entity';
+
+type JwtClaims = Record<string, unknown> & {
+  sub: string;
+  jti?: string;
+  typ?: 'access' | 'refresh';
+  iat?: number;
+  exp?: number;
+};
+
+type RequestAudit = {
+  ipAddress: string | null;
+  userAgent: string | string[] | null;
+  deviceFingerprint: string | null;
+};
+
+type TokenPair = {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: 'Bearer';
+  expiresIn: number;
+  refreshExpiresIn: number;
+};
+
+const JWT_HEADER = { alg: 'HS256', typ: 'JWT' };
+const JWT_RESERVED_CLAIMS = new Set(['iat', 'exp', 'nbf', 'jti', 'typ']);
+
+@Injectable()
+export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
+  constructor(
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokenRepository: Repository<RefreshToken>,
+    private readonly dataSource: DataSource,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async refresh(refreshToken: string, audit: RequestAudit): Promise<TokenPair> {
+    const payload = this.verifyRefreshToken(refreshToken);
+    const tokenHash = this.hashToken(refreshToken);
+    const now = new Date();
+
+    return this.dataSource.transaction(async (manager) => {
+      const token = await manager.findOne(RefreshToken, {
+        where: { tokenHash },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!token) {
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+
+      if (token.expiresAt.getTime() <= now.getTime()) {
+        throw new UnauthorizedException('Refresh token has expired');
+      }
+
+      if (token.revokedAt) {
+        await this.handleRefreshTokenReuse(manager, token, audit);
+        throw new UnauthorizedException('Refresh token has been revoked');
+      }
+
+      if (token.userId !== payload.sub) {
+        throw new UnauthorizedException(
+          'Refresh token does not match the authenticated user',
+        );
+      }
+
+      const coreClaims = this.getCoreClaims(payload);
+      const pair = this.createSignedTokenPair(coreClaims);
+      const replacement = this.refreshTokenRepository.create({
+        tokenHash: this.hashToken(pair.refreshToken),
+        userId: token.userId,
+        walletAddress: token.walletAddress,
+        familyId: token.familyId,
+        expiresAt: new Date(Date.now() + pair.refreshExpiresIn * 1000),
+        revokedAt: null,
+        replacedByTokenId: null,
+        userAgent: this.normalizeHeader(audit.userAgent),
+        ipAddress: audit.ipAddress,
+        deviceFingerprint: audit.deviceFingerprint,
+        lastUsedAt: null,
+        concurrentReuseDetectedAt: null,
+      });
+
+      const savedReplacement = await manager.save(RefreshToken, replacement);
+      token.revokedAt = now;
+      token.replacedByTokenId = savedReplacement.id;
+      token.lastUsedAt = now;
+      await manager.save(RefreshToken, token);
+
+      return pair;
+    });
+  }
+
+  async issueTokenPair(claims: JwtClaims, audit: RequestAudit): Promise<TokenPair> {
+    const pair = this.createSignedTokenPair(this.getCoreClaims(claims));
+    await this.refreshTokenRepository.save(
+      this.refreshTokenRepository.create({
+        tokenHash: this.hashToken(pair.refreshToken),
+        userId: claims.sub,
+        walletAddress:
+          this.getStringClaim(claims, 'walletAddress') ??
+          this.getStringClaim(claims, 'address'),
+        expiresAt: new Date(Date.now() + pair.refreshExpiresIn * 1000),
+        revokedAt: null,
+        replacedByTokenId: null,
+        userAgent: this.normalizeHeader(audit.userAgent),
+        ipAddress: audit.ipAddress,
+        deviceFingerprint: audit.deviceFingerprint,
+        lastUsedAt: null,
+        concurrentReuseDetectedAt: null,
+      }),
+    );
+
+    return pair;
+  }
+
+  private async handleRefreshTokenReuse(
+    manager: EntityManager,
+    token: RefreshToken,
+    audit: RequestAudit,
+  ): Promise<void> {
+    const now = new Date();
+    token.concurrentReuseDetectedAt ??= now;
+    await manager.save(RefreshToken, token);
+    await manager.update(
+      RefreshToken,
+      { familyId: token.familyId, revokedAt: IsNull() },
+      { revokedAt: now, concurrentReuseDetectedAt: now },
+    );
+
+    this.logger.warn({
+      message: 'Concurrent refresh token reuse detected',
+      refreshTokenId: token.id,
+      userId: token.userId,
+      familyId: token.familyId,
+      ipAddress: audit.ipAddress,
+      userAgent: this.normalizeHeader(audit.userAgent),
+      deviceFingerprint: audit.deviceFingerprint,
+    });
+  }
+
+  private createSignedTokenPair(coreClaims: JwtClaims): TokenPair {
+    const accessExpiresIn = this.getDurationSeconds('JWT_ACCESS_TOKEN_TTL', '15m');
+    const refreshExpiresIn = this.getDurationSeconds('JWT_REFRESH_TOKEN_TTL', '30d');
+
+    return {
+      accessToken: this.signJwt(
+        { ...coreClaims, typ: 'access', jti: randomUUID() },
+        accessExpiresIn,
+        this.accessSecret,
+      ),
+      refreshToken: this.signJwt(
+        { ...coreClaims, typ: 'refresh', jti: randomUUID() },
+        refreshExpiresIn,
+        this.refreshSecret,
+      ),
+      tokenType: 'Bearer',
+      expiresIn: accessExpiresIn,
+      refreshExpiresIn,
+    };
+  }
+
+  private verifyRefreshToken(token: string): JwtClaims {
+    const payload = this.verifyJwt(token, this.refreshSecret);
+    if (payload.typ !== 'refresh') {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    if (!payload.sub || typeof payload.sub !== 'string') {
+      throw new UnauthorizedException('Invalid refresh token claims');
+    }
+
+    return payload;
+  }
+
+  private signJwt(payload: JwtClaims, expiresInSeconds: number, secret: string): string {
+    const now = Math.floor(Date.now() / 1000);
+    const body = {
+      ...payload,
+      iat: now,
+      exp: now + expiresInSeconds,
+    };
+    const encodedHeader = this.base64UrlEncode(JSON.stringify(JWT_HEADER));
+    const encodedPayload = this.base64UrlEncode(JSON.stringify(body));
+    const signature = this.sign(`${encodedHeader}.${encodedPayload}`, secret);
+
+    return `${encodedHeader}.${encodedPayload}.${signature}`;
+  }
+
+  private verifyJwt(token: string, secret: string): JwtClaims {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    const [encodedHeader, encodedPayload, signature] = parts;
+    let header: typeof JWT_HEADER;
+    try {
+      header = JSON.parse(Buffer.from(encodedHeader, 'base64url').toString('utf8')) as typeof JWT_HEADER;
+    } catch {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    if (header.alg !== JWT_HEADER.alg || header.typ !== JWT_HEADER.typ) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    const expectedSignature = this.sign(`${encodedHeader}.${encodedPayload}`, secret);
+    if (!this.safeEquals(signature, expectedSignature)) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    let payload: JwtClaims;
+    try {
+      payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as JwtClaims;
+    } catch {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+    if (typeof payload.exp !== 'number' || payload.exp <= Math.floor(Date.now() / 1000)) {
+      throw new UnauthorizedException('Refresh token has expired');
+    }
+
+    return payload;
+  }
+
+  private sign(value: string, secret: string): string {
+    return createHmac('sha256', secret).update(value).digest('base64url');
+  }
+
+  private safeEquals(a: string, b: string): boolean {
+    const aBuffer = Buffer.from(a);
+    const bBuffer = Buffer.from(b);
+    return aBuffer.length === bBuffer.length && timingSafeEqual(aBuffer, bBuffer);
+  }
+
+  private hashToken(token: string): string {
+    return createHmac('sha256', this.refreshTokenHashSecret).update(token).digest('hex');
+  }
+
+  private getCoreClaims(payload: JwtClaims): JwtClaims {
+    return Object.fromEntries(
+      Object.entries(payload).filter(([key]) => !JWT_RESERVED_CLAIMS.has(key)),
+    ) as JwtClaims;
+  }
+
+  private getStringClaim(claims: JwtClaims, key: string): string | null {
+    const value = claims[key];
+    return typeof value === 'string' ? value : null;
+  }
+
+  private normalizeHeader(value: string | string[] | null): string | null {
+    if (Array.isArray(value)) {
+      return value.join(', ');
+    }
+
+    return value;
+  }
+
+  private getDurationSeconds(key: string, fallback: string): number {
+    const value = this.configService.get<string>(key) ?? fallback;
+    const match = /^(\d+)([smhd])?$/.exec(value);
+    if (!match) {
+      throw new Error(`${key} must be a duration like 900, 15m, 12h, or 30d`);
+    }
+
+    const amount = Number(match[1]);
+    const unit = match[2] ?? 's';
+    const multipliers = { s: 1, m: 60, h: 3600, d: 86400 };
+
+    return amount * multipliers[unit as keyof typeof multipliers];
+  }
+
+  private base64UrlEncode(value: string): string {
+    return Buffer.from(value).toString('base64url');
+  }
+
+  private get accessSecret(): string {
+    return this.configService.get<string>('JWT_ACCESS_TOKEN_SECRET') ?? this.jwtSecret;
+  }
+
+  private get refreshSecret(): string {
+    return this.configService.get<string>('JWT_REFRESH_TOKEN_SECRET') ?? this.jwtSecret;
+  }
+
+  private get refreshTokenHashSecret(): string {
+    return this.configService.get<string>('REFRESH_TOKEN_HASH_SECRET') ?? this.refreshSecret;
+  }
+
+  private get jwtSecret(): string {
+    const secret = this.configService.get<string>('JWT_SECRET');
+    if (secret) {
+      return secret;
+    }
+
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('JWT_SECRET must be configured in production');
+    }
+
+    return 'development-only-change-me';
+  }
+}

--- a/backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,3 @@
+export class RefreshTokenDto {
+  refreshToken!: string;
+}

--- a/backend/src/auth/entities/refresh-token.entity.ts
+++ b/backend/src/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,67 @@
+import {
+  BeforeInsert,
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { randomUUID } from 'crypto';
+
+@Entity({ name: 'refresh_tokens' })
+@Index(['userId'])
+@Index(['familyId'])
+@Index(['tokenHash'], { unique: true })
+export class RefreshToken {
+  @PrimaryColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'token_hash', type: 'varchar', length: 128 })
+  tokenHash!: string;
+
+  @Column({ name: 'user_id', type: 'varchar', length: 128 })
+  userId!: string;
+
+  @Column({ name: 'wallet_address', type: 'varchar', length: 128, nullable: true })
+  walletAddress!: string | null;
+
+  @Column({ name: 'family_id', type: 'uuid' })
+  familyId!: string;
+
+  @Column({ name: 'expires_at', type: 'timestamptz' })
+  expiresAt!: Date;
+
+  @Column({ name: 'revoked_at', type: 'timestamptz', nullable: true })
+  revokedAt!: Date | null;
+
+  @Column({ name: 'replaced_by_token_id', type: 'uuid', nullable: true })
+  replacedByTokenId!: string | null;
+
+  @Column({ name: 'user_agent', type: 'text', nullable: true })
+  userAgent!: string | null;
+
+  @Column({ name: 'ip_address', type: 'varchar', length: 64, nullable: true })
+  ipAddress!: string | null;
+
+  @Column({ name: 'device_fingerprint', type: 'varchar', length: 128, nullable: true })
+  deviceFingerprint!: string | null;
+
+  @Column({ name: 'last_used_at', type: 'timestamptz', nullable: true })
+  lastUsedAt!: Date | null;
+
+  @Column({ name: 'concurrent_reuse_detected_at', type: 'timestamptz', nullable: true })
+  concurrentReuseDetectedAt!: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt!: Date;
+
+  @BeforeInsert()
+  setIds(): void {
+    this.id ??= randomUUID();
+    this.familyId ??= randomUUID();
+  }
+}

--- a/backend/src/database/migrations/1760000000000-CreateRefreshTokens.ts
+++ b/backend/src/database/migrations/1760000000000-CreateRefreshTokens.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateRefreshTokens1760000000000 implements MigrationInterface {
+  name = 'CreateRefreshTokens1760000000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'refresh_tokens',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true },
+          { name: 'token_hash', type: 'varchar', length: '128', isNullable: false },
+          { name: 'user_id', type: 'varchar', length: '128', isNullable: false },
+          { name: 'wallet_address', type: 'varchar', length: '128', isNullable: true },
+          { name: 'family_id', type: 'uuid', isNullable: false },
+          { name: 'expires_at', type: 'timestamptz', isNullable: false },
+          { name: 'revoked_at', type: 'timestamptz', isNullable: true },
+          { name: 'replaced_by_token_id', type: 'uuid', isNullable: true },
+          { name: 'user_agent', type: 'text', isNullable: true },
+          { name: 'ip_address', type: 'varchar', length: '64', isNullable: true },
+          { name: 'device_fingerprint', type: 'varchar', length: '128', isNullable: true },
+          { name: 'last_used_at', type: 'timestamptz', isNullable: true },
+          { name: 'concurrent_reuse_detected_at', type: 'timestamptz', isNullable: true },
+          { name: 'created_at', type: 'timestamptz', default: 'now()' },
+          { name: 'updated_at', type: 'timestamptz', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'refresh_tokens',
+      new TableIndex({
+        name: 'IDX_refresh_tokens_token_hash',
+        columnNames: ['token_hash'],
+        isUnique: true,
+      }),
+    );
+    await queryRunner.createIndex(
+      'refresh_tokens',
+      new TableIndex({ name: 'IDX_refresh_tokens_user_id', columnNames: ['user_id'] }),
+    );
+    await queryRunner.createIndex(
+      'refresh_tokens',
+      new TableIndex({ name: 'IDX_refresh_tokens_family_id', columnNames: ['family_id'] }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('refresh_tokens', true);
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,17 +3,19 @@ import { AppModule } from './app.module';
 import { DataSource } from 'typeorm';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  
+  const app = await NestFactory.create(AppModule, {
+    // Disable NestJS built-in logger noise; our middleware handles request logs
+    logger:
+      process.env.NODE_ENV === 'production'
+        ? ['error', 'warn']
+        : ['log', 'error', 'warn', 'debug', 'verbose'],
+  });
+
   // Verify database connection before starting server
   const dataSource = app.get(DataSource);
   if (!dataSource.isInitialized) {
     throw new Error('Database connection failed to initialize');
   }
-  const app = await NestFactory.create(AppModule, {
-    // Disable NestJS built-in logger noise; our middleware handles request logs
-    logger: process.env.NODE_ENV === 'production' ? ['error', 'warn'] : ['log', 'error', 'warn', 'debug', 'verbose'],
-  });
 
   // Attach unhandled errors to res.locals so the logger middleware can read stack traces
   app.use((_err: Error, _req: unknown, res: { locals: { error: Error } }, next: (e: Error) => void) => {


### PR DESCRIPTION

Close #462 

Summary of the issue:
The API did not support refresh-token based session renewal, so users had to re-authenticate with their wallet instead of obtaining a new access token through a secure refresh flow.

Root cause:
Refresh tokens were not modeled or stored in the database, and there was no /auth/refresh endpoint to validate, rotate, revoke, expire, or audit refresh tokens.

Solution implemented:
Added a Nest auth module with POST /auth/refresh, persisted hashed refresh tokens, implemented refresh-token rotation, expiry handling, revoked-token handling, device audit metadata, and reuse detection with token-family revocation.

Key changes made:

Added RefreshToken entity and database migration.
Added /auth/refresh endpoint.
Added JWT signing/verification using Node crypto.
Added refresh-token rotation and old-token invalidation.
Added user agent, IP, and device fingerprint storage.
Added concurrent/reused refresh-token detection and security logging.
Added focused unit tests for rotation, expiration, and reuse detection.
Fixed existing app bootstrap/import issues that blocked clean compilation.
Trade-offs or considerations:

Refresh tokens are stored as HMAC hashes, not plaintext.
Reuse of a revoked rotated token revokes the entire token family as a conservative security response.
Production requires JWT_SECRET; development keeps a fallback for local work.
No new JWT package was added; implementation uses built-in Node crypto to avoid dependency churn.
Testing steps:

Run npm ci.
Run npm run build.
Run npm test -- auth.service.spec.ts --runInBand.
Run npm run migration:run.
Call POST /auth/refresh with a valid refresh token and confirm a new access/refresh pair is returned.
Reuse the old refresh token and confirm it returns 401 and triggers reuse handling.