### PR TITLE
feat: add authentication audit logging with retention and admin access

### DIFF
--- a/backend/src/auth/admin-access.guard.ts
+++ b/backend/src/auth/admin-access.guard.ts
@@ -1,0 +1,98 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'crypto';
+
+type JwtClaims = Record<string, unknown> & {
+  sub?: string;
+  typ?: 'access' | 'refresh';
+  role?: string;
+  roles?: unknown;
+  exp?: number;
+};
+
+@Injectable()
+export class AdminAccessGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{ headers: Record<string, string | undefined> }>();
+    const authorization = request.headers.authorization;
+    if (!authorization?.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Admin access requires a bearer token');
+    }
+    const token = authorization.slice('Bearer '.length).trim();
+    const claims = this.verifyJwt(token);
+    const isAdmin =
+      claims.role === 'admin' ||
+      (Array.isArray(claims.roles) && claims.roles.some((role) => role === 'admin'));
+
+    if (!isAdmin) {
+      throw new UnauthorizedException('Admin role required');
+    }
+    return true;
+  }
+
+  private verifyJwt(token: string): JwtClaims {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      throw new UnauthorizedException('Invalid access token');
+    }
+    const [encodedHeader, encodedPayload, signature] = parts;
+    let header: { alg?: string; typ?: string };
+    try {
+      header = JSON.parse(Buffer.from(encodedHeader, 'base64url').toString('utf8')) as {
+        alg?: string;
+        typ?: string;
+      };
+    } catch {
+      throw new UnauthorizedException('Invalid access token');
+    }
+    if (header.alg !== 'HS256' || header.typ !== 'JWT') {
+      throw new UnauthorizedException('Invalid access token');
+    }
+    const expectedSignature = this.sign(`${encodedHeader}.${encodedPayload}`, this.accessSecret);
+    if (!this.safeEquals(signature, expectedSignature)) {
+      throw new UnauthorizedException('Invalid access token');
+    }
+
+    let payload: JwtClaims;
+    try {
+      payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as JwtClaims;
+    } catch {
+      throw new UnauthorizedException('Invalid access token');
+    }
+
+    if (payload.typ !== 'access') {
+      throw new UnauthorizedException('Invalid access token type');
+    }
+    if (typeof payload.exp !== 'number' || payload.exp <= Math.floor(Date.now() / 1000)) {
+      throw new UnauthorizedException('Access token has expired');
+    }
+    return payload;
+  }
+
+  private sign(value: string, secret: string): string {
+    return createHmac('sha256', secret).update(value).digest('base64url');
+  }
+
+  private safeEquals(a: string, b: string): boolean {
+    const aBuffer = Buffer.from(a);
+    const bBuffer = Buffer.from(b);
+    return aBuffer.length === bBuffer.length && timingSafeEqual(aBuffer, bBuffer);
+  }
+
+  private get accessSecret(): string {
+    return this.configService.get<string>('JWT_ACCESS_TOKEN_SECRET') ?? this.jwtSecret;
+  }
+
+  private get jwtSecret(): string {
+    const secret = this.configService.get<string>('JWT_SECRET');
+    if (secret) {
+      return secret;
+    }
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('JWT_SECRET must be configured in production');
+    }
+    return 'development-only-change-me';
+  }
+}

--- a/backend/src/auth/audit-log.service.ts
+++ b/backend/src/auth/audit-log.service.ts
@@ -1,0 +1,296 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, EntityManager, Repository, SelectQueryBuilder } from 'typeorm';
+import { AuditEventType, AuditLog } from './entities/audit-log.entity';
+
+export type RequestAudit = {
+  ipAddress: string | null;
+  userAgent: string | string[] | null;
+  deviceFingerprint: string | null;
+};
+
+type LogEventInput = {
+  userId?: string | null;
+  eventType: AuditEventType;
+  audit: RequestAudit;
+  details?: Record<string, unknown>;
+  isSuspicious?: boolean;
+  timestamp?: Date;
+};
+
+type ListAuditLogsFilters = {
+  userId?: string;
+  eventType?: AuditEventType;
+  isSuspicious?: boolean;
+  start?: Date;
+  end?: Date;
+  limit: number;
+  offset: number;
+};
+
+@Injectable()
+export class AuditLogService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(AuditLogService.name);
+  private cleanupTimer: NodeJS.Timeout | null = null;
+
+  constructor(
+    @InjectRepository(AuditLog)
+    private readonly auditLogRepository: Repository<AuditLog>,
+    private readonly dataSource: DataSource,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.runRetentionCleanup();
+    this.cleanupTimer = setInterval(() => {
+      void this.runRetentionCleanup();
+    }, this.cleanupIntervalMs);
+    this.cleanupTimer.unref();
+  }
+
+  onModuleDestroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+
+  async logEvent(input: LogEventInput): Promise<AuditLog> {
+    return this.auditLogRepository.save(
+      this.auditLogRepository.create({
+        userId: input.userId ?? null,
+        eventType: input.eventType,
+        timestamp: input.timestamp ?? new Date(),
+        ipAddress: input.audit.ipAddress,
+        userAgent: this.normalizeHeader(input.audit.userAgent),
+        details: input.details ?? {},
+        isSuspicious: input.isSuspicious ?? false,
+      }),
+    );
+  }
+
+  async logLoginSuccess(input: {
+    userId: string;
+    walletAddress?: string | null;
+    audit: RequestAudit;
+  }): Promise<void> {
+    await this.logEvent({
+      userId: input.userId,
+      eventType: AuditEventType.LOGIN_SUCCESS,
+      audit: input.audit,
+      details: {
+        walletAddress: input.walletAddress ?? null,
+      },
+    });
+  }
+
+  async logLoginFailure(input: {
+    attemptedWalletAddress: string;
+    userId?: string | null;
+    reason?: string;
+    audit: RequestAudit;
+  }): Promise<void> {
+    const failureCountInWindow = await this.countRapidFailures(input);
+    const isSuspicious = failureCountInWindow + 1 >= this.suspiciousFailureThreshold;
+    await this.logEvent({
+      userId: input.userId ?? null,
+      eventType: AuditEventType.LOGIN_FAILURE,
+      audit: input.audit,
+      isSuspicious,
+      details: {
+        attemptedWalletAddress: input.attemptedWalletAddress,
+        reason: input.reason ?? null,
+        failureCountInWindow: failureCountInWindow + 1,
+      },
+    });
+
+    if (isSuspicious) {
+      await this.logEvent({
+        userId: input.userId ?? null,
+        eventType: AuditEventType.SUSPICIOUS_ACTIVITY,
+        audit: input.audit,
+        isSuspicious: true,
+        details: {
+          sourceEventType: AuditEventType.LOGIN_FAILURE,
+          attemptedWalletAddress: input.attemptedWalletAddress,
+          failureCountInWindow: failureCountInWindow + 1,
+          threshold: this.suspiciousFailureThreshold,
+        },
+      });
+    }
+  }
+
+  async logLogout(input: { userId: string; audit: RequestAudit }): Promise<void> {
+    await this.logEvent({
+      userId: input.userId,
+      eventType: AuditEventType.LOGOUT,
+      audit: input.audit,
+    });
+  }
+
+  async logRefreshTokenUsage(input: {
+    userId?: string | null;
+    success: boolean;
+    reason?: string;
+    audit: RequestAudit;
+  }): Promise<void> {
+    await this.logEvent({
+      userId: input.userId ?? null,
+      eventType: input.success
+        ? AuditEventType.REFRESH_TOKEN_SUCCESS
+        : AuditEventType.REFRESH_TOKEN_FAILURE,
+      audit: input.audit,
+      details: {
+        reason: input.reason ?? null,
+      },
+    });
+  }
+
+  async logPasswordEquivalentChange(input: {
+    userId: string;
+    audit: RequestAudit;
+    details?: Record<string, unknown>;
+  }): Promise<void> {
+    await this.logEvent({
+      userId: input.userId,
+      eventType: AuditEventType.PASSWORD_EQUIVALENT_CHANGED,
+      audit: input.audit,
+      details: input.details,
+    });
+  }
+
+  async logRoleAssignment(input: {
+    userId: string;
+    assignedRole: string;
+    assignedByUserId?: string;
+    audit: RequestAudit;
+  }): Promise<void> {
+    await this.logEvent({
+      userId: input.userId,
+      eventType: AuditEventType.ROLE_ASSIGNED,
+      audit: input.audit,
+      details: {
+        assignedRole: input.assignedRole,
+        assignedByUserId: input.assignedByUserId ?? null,
+      },
+    });
+  }
+
+  async listLogs(filters: ListAuditLogsFilters): Promise<{ items: AuditLog[]; total: number }> {
+    const query = this.applyFilters(this.auditLogRepository.createQueryBuilder('audit_log'), filters);
+    query.orderBy('audit_log.timestamp', 'DESC').limit(filters.limit).offset(filters.offset);
+
+    const [items, total] = await Promise.all([
+      query.getMany(),
+      this.applyFilters(this.auditLogRepository.createQueryBuilder('audit_log'), filters).getCount(),
+    ]);
+
+    return { items, total };
+  }
+
+  async runRetentionCleanup(): Promise<number> {
+    const cutoff = new Date(Date.now() - this.retentionDays * 24 * 60 * 60 * 1000);
+    try {
+      return await this.dataSource.transaction(async (manager: EntityManager) => {
+        const rowsToDelete = await manager
+          .createQueryBuilder(AuditLog, 'audit_log')
+          .where('audit_log.timestamp < :cutoff', { cutoff: cutoff.toISOString() })
+          .getCount();
+        await manager.query(
+          `
+            INSERT INTO audit_logs_archive (id, user_id, event_type, timestamp, ip_address, user_agent, details, is_suspicious)
+            SELECT id, user_id, event_type, timestamp, ip_address, user_agent, details, is_suspicious
+            FROM audit_logs
+            WHERE timestamp < $1
+            ON CONFLICT (id) DO NOTHING
+          `,
+          [cutoff.toISOString()],
+        );
+        await manager.query(`DELETE FROM audit_logs WHERE timestamp < $1`, [cutoff.toISOString()]);
+        return rowsToDelete;
+      });
+    } catch (error) {
+      this.logger.error('Failed audit log retention cleanup', error);
+      return 0;
+    }
+  }
+
+  private async countRapidFailures(input: {
+    attemptedWalletAddress: string;
+    audit: RequestAudit;
+  }): Promise<number> {
+    const windowStart = new Date(Date.now() - this.suspiciousFailureWindowSeconds * 1000);
+    const query = this.auditLogRepository
+      .createQueryBuilder('audit_log')
+      .where('audit_log.eventType = :eventType', { eventType: AuditEventType.LOGIN_FAILURE })
+      .andWhere('audit_log.timestamp >= :windowStart', { windowStart: windowStart.toISOString() });
+
+    if (input.audit.ipAddress) {
+      query.andWhere('audit_log.ipAddress = :ipAddress', { ipAddress: input.audit.ipAddress });
+    } else {
+      query.andWhere(`audit_log.details->>'attemptedWalletAddress' = :attemptedWalletAddress`, {
+        attemptedWalletAddress: input.attemptedWalletAddress,
+      });
+    }
+
+    return query.getCount();
+  }
+
+  private applyFilters(
+    query: SelectQueryBuilder<AuditLog>,
+    filters: ListAuditLogsFilters,
+  ): SelectQueryBuilder<AuditLog> {
+    if (filters.userId) {
+      query.andWhere('audit_log.userId = :userId', { userId: filters.userId });
+    }
+    if (filters.eventType) {
+      query.andWhere('audit_log.eventType = :eventType', { eventType: filters.eventType });
+    }
+    if (typeof filters.isSuspicious === 'boolean') {
+      query.andWhere('audit_log.isSuspicious = :isSuspicious', {
+        isSuspicious: filters.isSuspicious,
+      });
+    }
+    if (filters.start) {
+      query.andWhere('audit_log.timestamp >= :start', { start: filters.start.toISOString() });
+    }
+    if (filters.end) {
+      query.andWhere('audit_log.timestamp <= :end', { end: filters.end.toISOString() });
+    }
+
+    return query;
+  }
+
+  private normalizeHeader(value: string | string[] | null): string | null {
+    if (Array.isArray(value)) {
+      return value.join(', ');
+    }
+    return value;
+  }
+
+  private get retentionDays(): number {
+    return this.getInt('AUDIT_LOG_RETENTION_DAYS', 90);
+  }
+
+  private get cleanupIntervalMs(): number {
+    return this.getInt('AUDIT_LOG_CLEANUP_INTERVAL_MS', 60 * 60 * 1000);
+  }
+
+  private get suspiciousFailureThreshold(): number {
+    return this.getInt('AUDIT_SUSPICIOUS_FAILURE_THRESHOLD', 5);
+  }
+
+  private get suspiciousFailureWindowSeconds(): number {
+    return this.getInt('AUDIT_SUSPICIOUS_FAILURE_WINDOW_SECONDS', 300);
+  }
+
+  private getInt(key: string, fallback: number): number {
+    const value = this.configService.get<string>(key);
+    if (!value) {
+      return fallback;
+    }
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+}

--- a/backend/src/auth/audit-logs.controller.ts
+++ b/backend/src/auth/audit-logs.controller.ts
@@ -1,0 +1,82 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { AdminAccessGuard } from './admin-access.guard';
+import { AuditLogService } from './audit-log.service';
+import { AuditEventType } from './entities/audit-log.entity';
+
+@Controller('auth/audit-logs')
+@UseGuards(AdminAccessGuard)
+export class AuditLogsController {
+  constructor(private readonly auditLogService: AuditLogService) {}
+
+  @Get()
+  async list(@Query() query: Record<string, string | undefined>) {
+    const limit = this.parseInt(query.limit, 100, 1, 500);
+    const offset = this.parseInt(query.offset, 0, 0, Number.MAX_SAFE_INTEGER);
+    const eventType = this.parseEventType(query.eventType);
+    const start = this.parseDate(query.start);
+    const end = this.parseDate(query.end);
+    const isSuspicious = this.parseBoolean(query.isSuspicious);
+
+    return this.auditLogService.listLogs({
+      userId: query.userId,
+      eventType,
+      isSuspicious,
+      start,
+      end,
+      limit,
+      offset,
+    });
+  }
+
+  private parseInt(
+    value: string | undefined,
+    fallback: number,
+    min: number,
+    max: number,
+  ): number {
+    if (!value) {
+      return fallback;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed)) {
+      return fallback;
+    }
+    if (parsed < min) {
+      return min;
+    }
+    if (parsed > max) {
+      return max;
+    }
+    return parsed;
+  }
+
+  private parseDate(value: string | undefined): Date | undefined {
+    if (!value) {
+      return undefined;
+    }
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }
+
+  private parseBoolean(value: string | undefined): boolean | undefined {
+    if (!value) {
+      return undefined;
+    }
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+    return undefined;
+  }
+
+  private parseEventType(value: string | undefined): AuditEventType | undefined {
+    if (!value) {
+      return undefined;
+    }
+    return (Object.values(AuditEventType) as string[]).includes(value)
+      ? (value as AuditEventType)
+      : undefined;
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -3,12 +3,16 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { AuditLogsController } from './audit-logs.controller';
+import { AuditLogService } from './audit-log.service';
+import { AdminAccessGuard } from './admin-access.guard';
+import { AuditLog } from './entities/audit-log.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
 
 @Module({
-  imports: [ConfigModule, TypeOrmModule.forFeature([RefreshToken])],
-  controllers: [AuthController],
-  providers: [AuthService],
+  imports: [ConfigModule, TypeOrmModule.forFeature([RefreshToken, AuditLog])],
+  controllers: [AuthController, AuditLogsController],
+  providers: [AuthService, AuditLogService, AdminAccessGuard],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, IsNull } from 'typeorm';
+import { AuditLogService } from './audit-log.service';
 import { AuthService } from './auth.service';
 import { RefreshToken } from './entities/refresh-token.entity';
 
@@ -56,6 +57,14 @@ class InMemoryEntityManager {
 describe('AuthService', () => {
   let service: AuthService;
   let repository: InMemoryRefreshTokenRepository;
+  let auditLogService: {
+    logRefreshTokenUsage: jest.Mock;
+    logLoginSuccess: jest.Mock;
+    logLoginFailure: jest.Mock;
+    logLogout: jest.Mock;
+    logPasswordEquivalentChange: jest.Mock;
+    logRoleAssignment: jest.Mock;
+  };
   const config: Record<string, string> = {
     JWT_SECRET: 'test-secret',
     REFRESH_TOKEN_HASH_SECRET: 'hash-secret',
@@ -67,6 +76,14 @@ describe('AuthService', () => {
     jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
     repository = new InMemoryRefreshTokenRepository();
     const manager = new InMemoryEntityManager(repository);
+    auditLogService = {
+      logRefreshTokenUsage: jest.fn().mockResolvedValue(undefined),
+      logLoginSuccess: jest.fn().mockResolvedValue(undefined),
+      logLoginFailure: jest.fn().mockResolvedValue(undefined),
+      logLogout: jest.fn().mockResolvedValue(undefined),
+      logPasswordEquivalentChange: jest.fn().mockResolvedValue(undefined),
+      logRoleAssignment: jest.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -88,6 +105,10 @@ describe('AuthService', () => {
           useValue: {
             get: (key: string) => config[key],
           },
+        },
+        {
+          provide: AuditLogService,
+          useValue: auditLogService,
         },
       ],
     }).compile();
@@ -116,6 +137,9 @@ describe('AuthService', () => {
     expect(repository.tokens[0].replacedByTokenId).toBe(repository.tokens[1].id);
     expect(repository.tokens[1].revokedAt).toBeNull();
     expect(repository.tokens[1].ipAddress).toBe('10.0.0.2');
+    expect(auditLogService.logRefreshTokenUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, userId: 'user-1' }),
+    );
   });
 
   it('returns 401 when the refresh token is expired', async () => {
@@ -124,6 +148,9 @@ describe('AuthService', () => {
 
     await expect(service.refresh(issued.refreshToken, audit())).rejects.toBeInstanceOf(
       UnauthorizedException,
+    );
+    expect(auditLogService.logRefreshTokenUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, userId: 'user-1' }),
     );
   });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { createHmac, randomUUID, timingSafeEqual } from 'crypto';
 import { DataSource, EntityManager, IsNull, Repository } from 'typeorm';
+import { AuditLogService, RequestAudit } from './audit-log.service';
 import { RefreshToken } from './entities/refresh-token.entity';
 
 type JwtClaims = Record<string, unknown> & {
@@ -11,12 +12,6 @@ type JwtClaims = Record<string, unknown> & {
   typ?: 'access' | 'refresh';
   iat?: number;
   exp?: number;
-};
-
-type RequestAudit = {
-  ipAddress: string | null;
-  userAgent: string | string[] | null;
-  deviceFingerprint: string | null;
 };
 
 type TokenPair = {
@@ -39,63 +34,84 @@ export class AuthService {
     private readonly refreshTokenRepository: Repository<RefreshToken>,
     private readonly dataSource: DataSource,
     private readonly configService: ConfigService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   async refresh(refreshToken: string, audit: RequestAudit): Promise<TokenPair> {
-    const payload = this.verifyRefreshToken(refreshToken);
-    const tokenHash = this.hashToken(refreshToken);
-    const now = new Date();
+    let userId: string | null = null;
+    try {
+      const payload = this.verifyRefreshToken(refreshToken);
+      userId = payload.sub;
+      const tokenHash = this.hashToken(refreshToken);
+      const now = new Date();
 
-    return this.dataSource.transaction(async (manager) => {
-      const token = await manager.findOne(RefreshToken, {
-        where: { tokenHash },
-        lock: { mode: 'pessimistic_write' },
+      const pair = await this.dataSource.transaction(async (manager: EntityManager) => {
+        const token = await manager.findOne(RefreshToken, {
+          where: { tokenHash },
+          lock: { mode: 'pessimistic_write' },
+        });
+
+        if (!token) {
+          throw new UnauthorizedException('Invalid refresh token');
+        }
+
+        if (token.expiresAt.getTime() <= now.getTime()) {
+          throw new UnauthorizedException('Refresh token has expired');
+        }
+
+        if (token.revokedAt) {
+          await this.handleRefreshTokenReuse(manager, token, audit);
+          throw new UnauthorizedException('Refresh token has been revoked');
+        }
+
+        if (token.userId !== payload.sub) {
+          throw new UnauthorizedException(
+            'Refresh token does not match the authenticated user',
+          );
+        }
+
+        const coreClaims = this.getCoreClaims(payload);
+        const nextPair = this.createSignedTokenPair(coreClaims);
+        const replacement = this.refreshTokenRepository.create({
+          tokenHash: this.hashToken(nextPair.refreshToken),
+          userId: token.userId,
+          walletAddress: token.walletAddress,
+          familyId: token.familyId,
+          expiresAt: new Date(Date.now() + nextPair.refreshExpiresIn * 1000),
+          revokedAt: null,
+          replacedByTokenId: null,
+          userAgent: this.normalizeHeader(audit.userAgent),
+          ipAddress: audit.ipAddress,
+          deviceFingerprint: audit.deviceFingerprint,
+          lastUsedAt: null,
+          concurrentReuseDetectedAt: null,
+        });
+
+        const savedReplacement = await manager.save(RefreshToken, replacement);
+        token.revokedAt = now;
+        token.replacedByTokenId = savedReplacement.id;
+        token.lastUsedAt = now;
+        await manager.save(RefreshToken, token);
+
+        return nextPair;
       });
 
-      if (!token) {
-        throw new UnauthorizedException('Invalid refresh token');
-      }
-
-      if (token.expiresAt.getTime() <= now.getTime()) {
-        throw new UnauthorizedException('Refresh token has expired');
-      }
-
-      if (token.revokedAt) {
-        await this.handleRefreshTokenReuse(manager, token, audit);
-        throw new UnauthorizedException('Refresh token has been revoked');
-      }
-
-      if (token.userId !== payload.sub) {
-        throw new UnauthorizedException(
-          'Refresh token does not match the authenticated user',
-        );
-      }
-
-      const coreClaims = this.getCoreClaims(payload);
-      const pair = this.createSignedTokenPair(coreClaims);
-      const replacement = this.refreshTokenRepository.create({
-        tokenHash: this.hashToken(pair.refreshToken),
-        userId: token.userId,
-        walletAddress: token.walletAddress,
-        familyId: token.familyId,
-        expiresAt: new Date(Date.now() + pair.refreshExpiresIn * 1000),
-        revokedAt: null,
-        replacedByTokenId: null,
-        userAgent: this.normalizeHeader(audit.userAgent),
-        ipAddress: audit.ipAddress,
-        deviceFingerprint: audit.deviceFingerprint,
-        lastUsedAt: null,
-        concurrentReuseDetectedAt: null,
+      await this.auditLogService.logRefreshTokenUsage({
+        userId,
+        success: true,
+        audit,
       });
-
-      const savedReplacement = await manager.save(RefreshToken, replacement);
-      token.revokedAt = now;
-      token.replacedByTokenId = savedReplacement.id;
-      token.lastUsedAt = now;
-      await manager.save(RefreshToken, token);
 
       return pair;
-    });
+    } catch (error) {
+      await this.auditLogService.logRefreshTokenUsage({
+        userId,
+        success: false,
+        reason: error instanceof Error ? error.message : 'Unknown refresh failure',
+        audit,
+      });
+      throw error;
+    }
   }
 
   async issueTokenPair(claims: JwtClaims, audit: RequestAudit): Promise<TokenPair> {
@@ -119,6 +135,52 @@ export class AuthService {
     );
 
     return pair;
+  }
+
+  async logLoginSuccess(userId: string, walletAddress: string | null, audit: RequestAudit): Promise<void> {
+    await this.auditLogService.logLoginSuccess({
+      userId,
+      walletAddress,
+      audit,
+    });
+  }
+
+  async logLoginFailure(
+    attemptedWalletAddress: string,
+    audit: RequestAudit,
+    reason?: string,
+  ): Promise<void> {
+    await this.auditLogService.logLoginFailure({
+      attemptedWalletAddress,
+      reason,
+      audit,
+    });
+  }
+
+  async logLogout(userId: string, audit: RequestAudit): Promise<void> {
+    await this.auditLogService.logLogout({ userId, audit });
+  }
+
+  async logPasswordEquivalentChange(
+    userId: string,
+    audit: RequestAudit,
+    details?: Record<string, unknown>,
+  ): Promise<void> {
+    await this.auditLogService.logPasswordEquivalentChange({ userId, audit, details });
+  }
+
+  async logRoleAssignment(
+    userId: string,
+    assignedRole: string,
+    audit: RequestAudit,
+    assignedByUserId?: string,
+  ): Promise<void> {
+    await this.auditLogService.logRoleAssignment({
+      userId,
+      assignedRole,
+      assignedByUserId,
+      audit,
+    });
   }
 
   private async handleRefreshTokenReuse(

--- a/backend/src/auth/entities/audit-log.entity.ts
+++ b/backend/src/auth/entities/audit-log.entity.ts
@@ -1,0 +1,48 @@
+import { randomUUID } from 'crypto';
+import { BeforeInsert, Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+export enum AuditEventType {
+  LOGIN_SUCCESS = 'LOGIN_SUCCESS',
+  LOGIN_FAILURE = 'LOGIN_FAILURE',
+  LOGOUT = 'LOGOUT',
+  REFRESH_TOKEN_SUCCESS = 'REFRESH_TOKEN_SUCCESS',
+  REFRESH_TOKEN_FAILURE = 'REFRESH_TOKEN_FAILURE',
+  PASSWORD_EQUIVALENT_CHANGED = 'PASSWORD_EQUIVALENT_CHANGED',
+  ROLE_ASSIGNED = 'ROLE_ASSIGNED',
+  SUSPICIOUS_ACTIVITY = 'SUSPICIOUS_ACTIVITY',
+}
+
+@Entity({ name: 'audit_logs' })
+@Index(['userId'])
+@Index(['eventType'])
+@Index(['timestamp'])
+export class AuditLog {
+  @PrimaryColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'user_id', type: 'varchar', length: 128, nullable: true })
+  userId!: string | null;
+
+  @Column({ name: 'event_type', type: 'varchar', length: 64 })
+  eventType!: AuditEventType;
+
+  @Column({ name: 'timestamp', type: 'timestamptz', default: () => 'now()' })
+  timestamp!: Date;
+
+  @Column({ name: 'ip_address', type: 'varchar', length: 64, nullable: true })
+  ipAddress!: string | null;
+
+  @Column({ name: 'user_agent', type: 'text', nullable: true })
+  userAgent!: string | null;
+
+  @Column({ type: 'jsonb', default: () => "'{}'::jsonb" })
+  details!: Record<string, unknown>;
+
+  @Column({ name: 'is_suspicious', type: 'boolean', default: false })
+  isSuspicious!: boolean;
+
+  @BeforeInsert()
+  setId(): void {
+    this.id ??= randomUUID();
+  }
+}

--- a/backend/src/database/migrations/1761000000000-CreateAuditLogs.ts
+++ b/backend/src/database/migrations/1761000000000-CreateAuditLogs.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateAuditLogs1761000000000 implements MigrationInterface {
+  name = 'CreateAuditLogs1761000000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'audit_logs',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true },
+          { name: 'user_id', type: 'varchar', length: '128', isNullable: true },
+          { name: 'event_type', type: 'varchar', length: '64', isNullable: false },
+          { name: 'timestamp', type: 'timestamptz', default: 'now()', isNullable: false },
+          { name: 'ip_address', type: 'varchar', length: '64', isNullable: true },
+          { name: 'user_agent', type: 'text', isNullable: true },
+          { name: 'details', type: 'jsonb', default: "'{}'::jsonb", isNullable: false },
+          { name: 'is_suspicious', type: 'boolean', default: 'false', isNullable: false },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'audit_logs_archive',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true },
+          { name: 'user_id', type: 'varchar', length: '128', isNullable: true },
+          { name: 'event_type', type: 'varchar', length: '64', isNullable: false },
+          { name: 'timestamp', type: 'timestamptz', isNullable: false },
+          { name: 'ip_address', type: 'varchar', length: '64', isNullable: true },
+          { name: 'user_agent', type: 'text', isNullable: true },
+          { name: 'details', type: 'jsonb', isNullable: false },
+          { name: 'is_suspicious', type: 'boolean', isNullable: false },
+          { name: 'archived_at', type: 'timestamptz', default: 'now()', isNullable: false },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'audit_logs',
+      new TableIndex({ name: 'IDX_audit_logs_user_id', columnNames: ['user_id'] }),
+    );
+    await queryRunner.createIndex(
+      'audit_logs',
+      new TableIndex({ name: 'IDX_audit_logs_event_type', columnNames: ['event_type'] }),
+    );
+    await queryRunner.createIndex(
+      'audit_logs',
+      new TableIndex({ name: 'IDX_audit_logs_timestamp', columnNames: ['timestamp'] }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('audit_logs_archive', true);
+    await queryRunner.dropTable('audit_logs', true);
+  }
+}


### PR DESCRIPTION
Implement persistent audit logs for auth events with structured metadata, suspicious activity detection, and an admin-only query endpoint. Add retention cleanup with archival support and wire refresh token usage into the audit trail for compliance visibility.

Resolves #466 