### PR TITLE
feat(auth): add Swagger/OpenAPI documentation for auth endpoints

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,33 +1,96 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
+  HttpStatus,
+  Param,
   Post,
   Req,
   UnauthorizedException,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Request } from 'express';
 import { AuthService } from './auth.service';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
-import { Get, Param } from '@nestjs/common';
 import { NonceProvider } from '../providers/nonce.provider';
+import { NonceResponseDto } from './dto/nonce-response.dto';
 
+@ApiTags('Authentication')
 @Controller('auth')
 export class AuthController {
   constructor(
-  private readonly authService: AuthService,
-  private readonly nonceProvider: NonceProvider,
-) {}
+    private readonly authService: AuthService,
+    private readonly nonceProvider: NonceProvider,
+  ) {}
 
-@Get('nonce/:walletAddress')
-async generateNonce(
-  @Param('walletAddress') walletAddress: string,
-) {
-  return this.nonceProvider.generate(walletAddress);
-}
+  @Get('nonce/:walletAddress')
+  @ApiTags('Wallet')
+  @ApiOperation({
+    summary: 'Generate a nonce for wallet authentication',
+    description:
+      'Generates a one-time nonce tied to the given wallet address. ' +
+      'The client must sign this nonce with their private key and submit ' +
+      'it to POST /auth/login to obtain access and refresh tokens.',
+  })
+  @ApiParam({
+    name: 'walletAddress',
+    description: 'Stellar wallet public key (G... address)',
+    example: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Nonce generated successfully',
+    type: NonceResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid wallet address format',
+  })
+  async generateNonce(
+    @Param('walletAddress') walletAddress: string,
+  ): Promise<NonceResponseDto> {
+    return this.nonceProvider.generate(walletAddress);
+  }
 
   @Post('refresh')
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Session Management')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Refresh access token',
+    description:
+      'Exchanges a valid refresh token for a new access token and a ' +
+      'rotated refresh token. The old refresh token is invalidated after use.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Tokens refreshed successfully',
+    schema: {
+      example: {
+        accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+        refreshToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Refresh token is missing, invalid, or expired',
+  })
+  @ApiResponse({
+    status: HttpStatus.TOO_MANY_REQUESTS,
+    description: 'Rate limit exceeded',
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: 'Unexpected server error',
+  })
   refresh(@Body() body: RefreshTokenDto, @Req() request: Request) {
     if (!body?.refreshToken || typeof body.refreshToken !== 'string') {
       throw new UnauthorizedException('Refresh token is required');
@@ -53,6 +116,4 @@ async generateNonce(
     const header = request.headers['x-device-fingerprint'];
     return typeof header === 'string' && header.length > 0 ? header : null;
   }
-
-  
 }

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,12 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEthereumAddress, IsString } from 'class-validator';
 
 export class LoginDto {
+  @ApiProperty({
+    description: 'Stellar wallet public key (G... address)',
+    example: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+  })
   @IsEthereumAddress()
   walletAddress: string;
 
+  @ApiProperty({
+    description: 'Cryptographic signature of the nonce using the wallet private key',
+    example: '3045022100a1b2c3...d4e5f6',
+  })
   @IsString()
   signature: string;
 
+  @ApiProperty({
+    description: 'The signed message (nonce value returned by GET /auth/nonce/:walletAddress)',
+    example: 'a3f8c2d1-7b4e-4f9a-8c3d-2e1f0b5a6c7d',
+  })
   @IsString()
   message: string;
 }

--- a/backend/src/auth/dto/nonce-response.dto.ts
+++ b/backend/src/auth/dto/nonce-response.dto.ts
@@ -1,5 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class NonceResponseDto {
+  @ApiProperty({
+    description: 'One-time nonce to be signed by the wallet',
+    example: 'a3f8c2d1-7b4e-4f9a-8c3d-2e1f0b5a6c7d',
+  })
   nonce: string;
 
+  @ApiProperty({
+    description: 'ISO 8601 timestamp when the nonce expires',
+    example: '2026-05-28T13:00:00.000Z',
+  })
   expiresAt: string;
 }

--- a/backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/src/auth/dto/refresh-token.dto.ts
@@ -1,3 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class RefreshTokenDto {
+  @ApiProperty({
+    description: 'JWT refresh token obtained from a previous login or refresh',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+  })
   refreshToken!: string;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,10 +1,10 @@
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { DataSource } from 'typeorm';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
-    // Disable NestJS built-in logger noise; our middleware handles request logs
     logger:
       process.env.NODE_ENV === 'production'
         ? ['error', 'warn']
@@ -17,7 +17,25 @@ async function bootstrap() {
     throw new Error('Database connection failed to initialize');
   }
 
-  // Attach unhandled errors to res.locals so the logger middleware can read stack traces
+  // Swagger UI â€” available in development and staging only
+  if (process.env.NODE_ENV !== 'production') {
+    const config = new DocumentBuilder()
+      .setTitle('SkillSync API')
+      .setDescription('SkillSync Server REST API documentation')
+      .setVersion('1.0')
+      .addBearerAuth(
+        { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+        'Bearer Auth',
+      )
+      .addTag('Authentication', 'Wallet-based authentication endpoints')
+      .addTag('Wallet', 'Wallet nonce generation')
+      .addTag('Session Management', 'Token refresh and session control')
+      .build();
+
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api/docs', app, document);
+  }
+
   app.use((_err: Error, _req: unknown, res: { locals: { error: Error } }, next: (e: Error) => void) => {
     res.locals.error = _err;
     next(_err);


### PR DESCRIPTION
## Summary

Fully documents all authentication endpoints using NestJS Swagger/OpenAPI decorators, addressing all acceptance criteria in issue

## Changes

- `auth.controller.ts` - added `@ApiTags`, `@ApiOperation`, `@ApiParam`, `@ApiResponse`, `@ApiBearerAuth` decorators
- `main.ts` - configured SwaggerModule to serve Swagger UI at `/api/docs` in non-production environments
- `dto/refresh-token.dto.ts` - added `@ApiProperty` with description and example
- `dto/nonce-response.dto.ts` - added `@ApiProperty` for both fields
- `dto/login.dto.ts` - added `@ApiProperty` for all fields

## Acceptance Criteria Met

- Swagger UI at `/api/docs` (non-production only)
- All auth endpoints documented with request/response schemas
- Bearer Auth security scheme configured
- Error responses documented (400, 401, 429, 500)
- DTO properties include descriptions and examples
- Tags: Authentication, Wallet, Session Management
