### PR TITLE
feat: add POST /auth/revoke-all endpoint to invalidate all user sessions

### DIFF
--- a/backend/src/auth/revoke-all-sessions.controller.ts
+++ b/backend/src/auth/revoke-all-sessions.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  Post,
+  Req,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
+import { RefreshToken } from '../entities/refresh-token.entity';
+
+interface JwtUser {
+  sub: string;
+}
+
+/**
+ * POST /auth/revoke-all
+ *
+ * Invalidates all active refresh tokens for the authenticated user.
+ * Requires a valid Bearer JWT in the Authorization header.
+ */
+@Controller('auth')
+export class RevokeAllSessionsController {
+  constructor(
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokens: Repository<RefreshToken>,
+  ) {}
+
+  @Post('revoke-all')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async revokeAll(
+    @Req() req: Request & { user: JwtUser },
+  ): Promise<{ revoked: number }> {
+    const userId = req.user.sub;
+    const now = new Date();
+
+    const result = await this.refreshTokens
+      .createQueryBuilder()
+      .update(RefreshToken)
+      .set({ revokedAt: now })
+      .where('userId = :userId AND revokedAt IS NULL', { userId })
+      .execute();
+
+    return { revoked: result.affected ?? 0 };
+  }
+}


### PR DESCRIPTION
## Summary
Adds \ackend/src/auth/revoke-all-sessions.controller.ts\ implementing \POST /auth/revoke-all\.
- Protected by \JwtAuthGuard\
- Sets \evokedAt = now\ on all active \RefreshToken\ rows for the authenticated user
- Returns \{ revoked: <count> }\

closes #471