### PR TITLE
feat(swagger): configure Swagger UI at /api/docs

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.1",
     "pg": "^8.21.0",
+    "@nestjs/swagger": "^8.1.0",
     "@nestjs/terminus": "^11.1.1",
     "ioredis": "^5.11.0",
     "reflect-metadata": "^0.2.2",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { DataSource } from 'typeorm';
 
@@ -22,6 +23,24 @@ async function bootstrap() {
     res.locals.error = _err;
     next(_err);
   });
+
+
+  if (process.env.NODE_ENV !== 'production') {
+    const swaggerConfig = new DocumentBuilder()
+      .setTitle('SkillSync API')
+      .setDescription('SkillSync authentication and user management API')
+      .setVersion('1.0')
+      .addBearerAuth(
+        { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+        'Bearer Auth',
+      )
+      .addTag('Authentication')
+      .addTag('Wallet')
+      .addTag('Session Management')
+      .build();
+    const document = SwaggerModule.createDocument(app, swaggerConfig);
+    SwaggerModule.setup('api/docs', app, document);
+  }
 
   await app.listen(process.env.PORT ?? 3000);
 }


### PR DESCRIPTION
## Summary

Adds `@nestjs/swagger` and configures Swagger UI at `/api/docs` (disabled in production):

- **`backend/src/main.ts`** — initializes `DocumentBuilder` with Bearer Auth security scheme and tags (`Authentication`, `Wallet`, `Session Management`)
- **`backend/package.json`** — adds `@nestjs/swagger ^8.1.0` as a dependency

Swagger UI is only enabled when `NODE_ENV !== 'production'`, keeping it off in production deployments.

## Related

closes #472
