### PR TITLE
test: unit tests for lock_funds — success, zero amount, duplicate session

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,15 +1,52 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
-#[contract]
-pub struct Contract;
+#[contracttype] pub enum DataKey { Session(u64) }
+#[contracttype] #[derive(Clone, PartialEq)] pub enum SessionState { Locked, Completed, Approved, Refunded }
+#[contracttype] #[derive(Clone)]
+pub struct Session { pub buyer: Address, pub seller: Address, pub amount: i128, pub state: SessionState }
 
+#[contract] pub struct EscrowContract;
 #[contractimpl]
-impl Contract {
-    pub fn hello(env: Env, to: String) -> Vec<String> {
-        vec![&env, String::from_str(&env, "Hello"), to]
+impl EscrowContract {
+    pub fn lock_funds(env: Env, session_id: u64, buyer: Address, seller: Address, amount: i128, token_id: Address) {
+        buyer.require_auth();
+        assert!(amount > 0, "amount must be positive");
+        assert!(!env.storage().persistent().has(&DataKey::Session(session_id)), "duplicate session");
+        token::Client::new(&env, &token_id).transfer(&buyer, &env.current_contract_address(), &amount);
+        env.storage().persistent().set(&DataKey::Session(session_id), &Session { buyer, seller, amount, state: SessionState::Locked });
+        env.events().publish((symbol_short!("LOCKED"), session_id), amount);
+    }
+    pub fn complete(env: Env, session_id: u64) {
+        let mut s: Session = env.storage().persistent().get(&DataKey::Session(session_id)).unwrap();
+        s.seller.require_auth();
+        assert_eq!(s.state, SessionState::Locked);
+        s.state = SessionState::Completed;
+        env.storage().persistent().set(&DataKey::Session(session_id), &s);
+    }
+    pub fn approve(env: Env, session_id: u64, token_id: Address, fee_bps: u32, treasury: Address) {
+        let mut s: Session = env.storage().persistent().get(&DataKey::Session(session_id)).unwrap();
+        s.buyer.require_auth();
+        assert_eq!(s.state, SessionState::Completed);
+        let fee = s.amount * fee_bps as i128 / 10_000;
+        let payout = s.amount - fee;
+        let t = token::Client::new(&env, &token_id);
+        t.transfer(&env.current_contract_address(), &s.seller, &payout);
+        if fee > 0 { t.transfer(&env.current_contract_address(), &treasury, &fee); }
+        s.state = SessionState::Approved;
+        env.storage().persistent().set(&DataKey::Session(session_id), &s);
+    }
+    pub fn refund(env: Env, session_id: u64, token_id: Address) {
+        let mut s: Session = env.storage().persistent().get(&DataKey::Session(session_id)).unwrap();
+        s.buyer.require_auth();
+        assert_eq!(s.state, SessionState::Locked);
+        token::Client::new(&env, &token_id).transfer(&env.current_contract_address(), &s.buyer, &s.amount);
+        s.state = SessionState::Refunded;
+        env.storage().persistent().set(&DataKey::Session(session_id), &s);
+        env.events().publish((symbol_short!("REFUNDED"), session_id), s.amount);
+    }
+    pub fn get_session(env: Env, session_id: u64) -> Session {
+        env.storage().persistent().get(&DataKey::Session(session_id)).unwrap()
     }
 }
-
-#[cfg(test)]
-mod test;
+#[cfg(test)] mod test;

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -1,21 +1,44 @@
 #![cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::{Address as _, MockAuth, MockAuthInvoke}, vec, Env, IntoVal};
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
 
-use super::{Contract, ContractClient};
-use soroban_sdk::{vec, Env, String};
+fn setup() -> (Env, Address, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    StellarAssetClient::new(&env, &token_id).mint(&buyer, &1000);
+    (env, buyer, seller, treasury, token_id, admin)
+}
 
 #[test]
-fn test() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
+fn test_lock_funds_success() {
+    let (env, buyer, seller, _, token_id, _) = setup();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.lock_funds(&1, &buyer, &seller, &500, &token_id);
+    let s = client.get_session(&1);
+    assert_eq!(s.state, SessionState::Locked);
+    assert_eq!(TokenClient::new(&env, &token_id).balance(&contract_id), 500);
+}
 
-    let words = client.hello(&String::from_str(&env, "Dev"));
-    assert_eq!(
-        words,
-        vec![
-            &env,
-            String::from_str(&env, "Hello"),
-            String::from_str(&env, "Dev"),
-        ]
-    );
+#[test]
+#[should_panic]
+fn test_lock_funds_zero_amount_reverts() {
+    let (env, buyer, seller, _, token_id, _) = setup();
+    let client = EscrowContractClient::new(&env, &env.register(EscrowContract, ()));
+    client.lock_funds(&1, &buyer, &seller, &0, &token_id);
+}
+
+#[test]
+#[should_panic]
+fn test_lock_funds_duplicate_session_reverts() {
+    let (env, buyer, seller, _, token_id, _) = setup();
+    let client = EscrowContractClient::new(&env, &env.register(EscrowContract, ()));
+    client.lock_funds(&1, &buyer, &seller, &100, &token_id);
+    client.lock_funds(&1, &buyer, &seller, &100, &token_id);
 }


### PR DESCRIPTION
## Summary
Implements the escrow contract (contract/src/lib.rs) and adds unit tests in contract/src/test.rs covering:
- Buyer can lock funds with sufficient balance ✅
- Contract balance increases by exact amount ✅
- Zero amount reverts ✅
- Duplicate session ID reverts ✅

closes #535