### PR TITLE
event session

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -429,8 +429,10 @@ impl SkillSyncEscrow {
         session.status = Status::Completed;
         session.completed_at = env.ledger().timestamp();
         Self::save_session_internal(&env, &session_id, &session);
-        env.events()
-            .publish((Symbol::new(&env, "SessionCompleted"), session_id), ());
+        env.events().publish(
+            (Symbol::new(&env, "SessionCompleted"), session_id),
+            (session.seller.clone(), session.completed_at),
+        );
     }
 
     // ── #526: approve_session ─────────────────────────────────────────────────

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -574,12 +574,17 @@ mod test_skillsync_escrow {
         let id = make_id(&env, 11);
         client.lock_funds(&id, &buyer, &seller, &200, &token_id);
         client.complete_session(&id);
+        let s = client.get_session(&id);
         let events = env.events().all();
         let last = events.last().unwrap();
         assert_eq!(last.0, cid);
         assert_eq!(
             last.1,
             (Symbol::new(&env, "SessionCompleted"), id.clone()).into_val(&env)
+        );
+        assert_eq!(
+            last.2,
+            (seller.clone(), s.completed_at).into_val(&env)
         );
     }
 


### PR DESCRIPTION
closes #546 

 Description
This PR adds the `SessionCompleted` event emission when a seller marks a session as complete. This event provides on-chain visibility into session lifecycle completion, enabling dApps, indexers, and monitoring systems to track when sessions successfully conclude.



