### PR TITLE
Add startup admin seed and sync branch with upstream main

### DIFF
--- a/src/database/seeds/admin-seed.service.spec.ts
+++ b/src/database/seeds/admin-seed.service.spec.ts
@@ -1,0 +1,197 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { AdminSeedService, SeedResult } from './admin-seed.service';
+import { Role } from '../../modules/auth/entities/role.entity';
+import { User } from '../../modules/auth/entities/user.entity';
+
+describe('AdminSeedService', () => {
+  let service: AdminSeedService;
+  let mockDataSource: jest.Mocked<DataSource>;
+  let mockConfigService: jest.Mocked<ConfigService>;
+  let mockRoleRepository: jest.Mocked<any>;
+  let mockUserRepository: jest.Mocked<any>;
+  let mockQueryRunner: any;
+
+  const mockAdminWallet = 'GD5HYXSWXWFDGWZQOB3Q2SHDTSVAU4AYTPULFTBEFVNOTIFNDGXEDKGM';
+  const normalizedWallet = 'gd5hyxswxwfdgwzqob3q2shdtsvau4aytpulftbefvnotifndgxedkgm';
+
+  beforeEach(async () => {
+    // Setup mock query runner
+    mockQueryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn(),
+      manager: {
+        save: jest.fn(),
+      },
+    };
+
+    // Setup mock data source
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    } as any;
+
+    // Setup mock config service
+    mockConfigService = {
+      get: jest.fn(),
+    } as any;
+
+    // Setup mock repositories
+    mockRoleRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    mockUserRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminSeedService,
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+        {
+          provide: getRepositoryToken(Role),
+          useValue: mockRoleRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AdminSeedService>(AdminSeedService);
+  });
+
+  describe('seed', () => {
+    it('should be defined', () => {
+      expect(service).toBeDefined();
+    });
+
+    it('should skip seeding when DISABLE_SEED is true', async () => {
+      mockConfigService.get.mockReturnValueOnce('true');
+
+      const result = await service.seed();
+
+      expect(result.roleCreated).toBe(false);
+      expect(result.roleAlreadyExists).toBe(true);
+      expect(result.userCreated).toBe(false);
+      expect(result.userAlreadyExists).toBe(true);
+      expect(result.message).toBe('Seeding disabled');
+      expect(mockQueryRunner.startTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should create admin role and user successfully', async () => {
+      const adminRoleId = '123e4567-e89b-12d3-a456-426614174000';
+      const adminUserId = '223e4567-e89b-12d3-a456-426614174000';
+
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'DISABLE_SEED') return undefined;
+        if (key === 'DEFAULT_ADMIN_WALLET') return mockAdminWallet;
+        return undefined;
+      });
+
+      const mockRole = { id: adminRoleId, name: 'admin' };
+      const mockUser = { id: adminUserId, walletAddress: normalizedWallet };
+
+      mockRoleRepository.create.mockReturnValue(mockRole);
+      mockUserRepository.create.mockReturnValue(mockUser);
+
+      // Mock role doesn't exist and is inserted
+      mockQueryRunner.query
+        .mockResolvedValueOnce([]) // No existing role
+        .mockResolvedValueOnce([mockRole]) // Inserted role returned
+        .mockResolvedValueOnce([]) // No existing user
+        .mockResolvedValueOnce(undefined); // Insert user_role
+
+      mockQueryRunner.manager.save
+        .mockResolvedValueOnce(mockRole)
+        .mockResolvedValueOnce(mockUser);
+
+      const result = await service.seed();
+
+      expect(result.roleCreated).toBe(true);
+      expect(result.userCreated).toBe(true);
+      expect(result.message).toContain('Admin role created');
+      expect(result.message).toContain('Admin user created');
+      expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it('should handle existing admin role', async () => {
+      const adminRoleId = '123e4567-e89b-12d3-a456-426614174000';
+
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'DISABLE_SEED') return undefined;
+        if (key === 'DEFAULT_ADMIN_WALLET') return mockAdminWallet;
+        return undefined;
+      });
+
+      const mockRole = { id: adminRoleId, name: 'admin' };
+
+      mockRoleRepository.create.mockReturnValue(mockRole);
+
+      // Mock role already exists
+      mockQueryRunner.query
+        .mockResolvedValueOnce([mockRole]) // Existing role found
+        .mockResolvedValueOnce([]) // No existing user
+        .mockResolvedValueOnce(undefined); // Insert user_role
+
+      const mockUser = { id: '223e4567-e89b-12d3-a456-426614174000', walletAddress: normalizedWallet };
+      mockUserRepository.create.mockReturnValue(mockUser);
+      mockQueryRunner.manager.save.mockResolvedValueOnce(mockUser);
+
+      const result = await service.seed();
+
+      expect(result.roleCreated).toBe(false);
+      expect(result.roleAlreadyExists).toBe(true);
+      expect(result.message).toContain('Admin role already exists');
+    });
+
+    it('should skip user creation when DEFAULT_ADMIN_WALLET is not set', async () => {
+      mockConfigService.get.mockReturnValue(undefined);
+
+      const adminRoleId = '123e4567-e89b-12d3-a456-426614174000';
+      const mockRole = { id: adminRoleId, name: 'admin' };
+
+      mockRoleRepository.create.mockReturnValue(mockRole);
+
+      // Mock role doesn't exist and is inserted
+      mockQueryRunner.query
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([mockRole]);
+      mockQueryRunner.manager.save.mockResolvedValueOnce(mockRole);
+
+      const result = await service.seed();
+
+      expect(result.roleCreated).toBe(true);
+      expect(result.userCreated).toBe(false);
+      expect(result.message).toContain('No default admin wallet configured');
+    });
+
+    it('should rollback transaction on error', async () => {
+      mockConfigService.get.mockReturnValue(undefined);
+
+      mockQueryRunner.query.mockRejectedValueOnce(new Error('Database error'));
+
+      await expect(service.seed()).rejects.toThrow('Database error');
+
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+      expect(mockQueryRunner.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/database/seeds/admin-seed.service.ts
+++ b/src/database/seeds/admin-seed.service.ts
@@ -1,0 +1,248 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource, QueryRunner } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Role } from '../../modules/auth/entities/role.entity';
+import { User, UserStatus } from '../../modules/auth/entities/user.entity';
+import { normalizeWalletAddress } from '../../common/utils/wallet.utils';
+
+export interface SeedResult {
+  roleCreated: boolean;
+  roleAlreadyExists: boolean;
+  userCreated: boolean;
+  userAlreadyExists: boolean;
+  message: string;
+}
+
+@Injectable()
+export class AdminSeedService {
+  private readonly logger = new Logger(AdminSeedService.name);
+
+  constructor(
+    private dataSource: DataSource,
+    private configService: ConfigService,
+    @InjectRepository(Role)
+    private roleRepository: Repository<Role>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+  ) {}
+
+  /**
+   * Run the admin seed logic with full transaction support
+   */
+  async seed(): Promise<SeedResult> {
+    // Check if seeding is disabled
+    const disableSeed = this.configService.get<string>('DISABLE_SEED');
+    if (disableSeed === 'true') {
+      this.logger.log('Seeding is disabled via DISABLE_SEED=true');
+      return {
+        roleCreated: false,
+        roleAlreadyExists: true,
+        userCreated: false,
+        userAlreadyExists: true,
+        message: 'Seeding disabled',
+      };
+    }
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      // Step 1: Seed admin role
+      const roleResult = await this.seedAdminRole(queryRunner);
+
+      // Step 2: Seed admin user
+      const userResult = await this.seedAdminUser(queryRunner, roleResult);
+
+      // Commit transaction
+      await queryRunner.commitTransaction();
+
+      const message = this.buildResultMessage(roleResult, userResult);
+      this.logger.log(`Admin seeding completed: ${message}`);
+
+      return {
+        roleCreated: roleResult.created,
+        roleAlreadyExists: roleResult.alreadyExists,
+        userCreated: userResult.created,
+        userAlreadyExists: userResult.alreadyExists,
+        message,
+      };
+    } catch (error) {
+      // Rollback transaction on error
+      await queryRunner.rollbackTransaction();
+      this.logger.error(`Admin seeding failed: ${error.message}`, error.stack);
+      throw error;
+    } finally {
+      // Release the query runner
+      await queryRunner.release();
+    }
+  }
+
+  /**
+   * Seed the admin role (idempotent)
+   */
+  private async seedAdminRole(
+    queryRunner: QueryRunner,
+  ): Promise<{ created: boolean; alreadyExists: boolean; role: Role }> {
+    const adminRoleName = 'admin';
+
+    const existingRoles = await queryRunner.query(
+      `SELECT * FROM roles WHERE name = $1`,
+      [adminRoleName],
+    );
+
+    if (existingRoles && existingRoles.length > 0) {
+      this.logger.log(`Admin role already exists`);
+      return {
+        created: false,
+        alreadyExists: true,
+        role: existingRoles[0] as Role,
+      };
+    }
+
+    const savedRoleResult = await queryRunner.query(
+      `INSERT INTO roles (name, description)
+       VALUES ($1, $2)
+       ON CONFLICT (name)
+       DO UPDATE SET description = EXCLUDED.description
+       RETURNING *`,
+      [adminRoleName, 'Administrator role with full system permissions'],
+    );
+
+    const savedRole = Array.isArray(savedRoleResult)
+      ? savedRoleResult[0]
+      : savedRoleResult;
+
+    if (!savedRole) {
+      throw new Error('Failed to create or retrieve admin role');
+    }
+
+    this.logger.log(`Created or updated admin role with ID: ${savedRole.id}`);
+
+    return {
+      created: true,
+      alreadyExists: false,
+      role: savedRole as Role,
+    };
+  }
+
+  /**
+   * Seed the default admin user (idempotent)
+   */
+  private async seedAdminUser(
+    queryRunner: QueryRunner,
+    roleResult: { created: boolean; alreadyExists: boolean; role: Role },
+  ): Promise<{ created: boolean; alreadyExists: boolean; user?: User }> {
+    const adminWallet = this.configService.get<string>('DEFAULT_ADMIN_WALLET');
+
+    if (!adminWallet) {
+      this.logger.warn(
+        'DEFAULT_ADMIN_WALLET environment variable not set. Skipping admin user creation.',
+      );
+      return {
+        created: false,
+        alreadyExists: false,
+        user: undefined,
+      };
+    }
+
+    const normalizedWallet = normalizeWalletAddress(adminWallet);
+
+    const existingUser = await queryRunner.query(
+      `SELECT u.* FROM users u WHERE u."walletAddress" = $1`,
+      [normalizedWallet],
+    );
+
+    if (existingUser && existingUser.length > 0) {
+      this.logger.log(`Admin user already exists for wallet: ${normalizedWallet}`);
+      await this.ensureUserHasAdminRole(
+        queryRunner,
+        existingUser[0].id,
+        roleResult.role.id,
+      );
+
+      return {
+        created: false,
+        alreadyExists: true,
+        user: existingUser[0] as User,
+      };
+    }
+
+    const adminUser = this.userRepository.create({
+      walletAddress: normalizedWallet,
+      nonce: null,
+      tokenVersion: 1,
+      status: UserStatus.ACTIVE,
+    });
+
+    const savedUser = await queryRunner.manager.save(adminUser);
+    this.logger.log(`Created new admin user with ID: ${savedUser.id}`);
+
+    await queryRunner.query(
+      `INSERT INTO user_roles ("userId", "roleId") VALUES ($1, $2)
+       ON CONFLICT DO NOTHING`,
+      [savedUser.id, roleResult.role.id],
+    );
+
+    return {
+      created: true,
+      alreadyExists: false,
+      user: savedUser,
+    };
+  }
+
+  /**
+   * Ensure the user has the admin role assigned
+   */
+  private async ensureUserHasAdminRole(
+    queryRunner: QueryRunner,
+    userId: string,
+    roleId: string,
+  ): Promise<void> {
+    const userRole = await queryRunner.query(
+      `SELECT 1 FROM user_roles WHERE "userId" = $1 AND "roleId" = $2`,
+      [userId, roleId],
+    );
+
+    if (!userRole || userRole.length === 0) {
+      await queryRunner.query(
+        `INSERT INTO user_roles ("userId", "roleId") VALUES ($1, $2)
+         ON CONFLICT DO NOTHING`,
+        [userId, roleId],
+      );
+      this.logger.log(`Assigned admin role to user: ${userId}`);
+    }
+  }
+
+  /**
+   * Build result message based on seed results
+   */
+  private buildResultMessage(roleResult: any, userResult: any): string {
+    if (roleResult.alreadyExists && userResult.user && userResult.alreadyExists) {
+      return 'Admin already exists';
+    }
+
+    const parts: string[] = [];
+
+    if (roleResult.created) {
+      parts.push('Admin role created');
+    } else if (roleResult.alreadyExists) {
+      parts.push('Admin role already exists');
+    }
+
+    if (userResult.user === undefined) {
+      parts.push('No default admin wallet configured');
+    } else if (userResult.created) {
+      parts.push('Admin user created');
+    } else if (userResult.alreadyExists) {
+      parts.push('Admin user already exists');
+    }
+
+    if (parts.every((part) => part.endsWith('already exists'))) {
+      return 'Admin already exists';
+    }
+
+    return `Admin seeded successfully: ${parts.join('; ')}`;
+  }
+}


### PR DESCRIPTION
Closes #465 
This PR rebases the feature branch onto upstream/main, resolves the seed file conflicts, and ensures the startup admin seed runs on application bootstrap. The seed inserts the admin role if missing, creates a default admin user from DEFAULT_ADMIN_WALLET, assigns the admin role automatically, and is idempotent.