### PR TITLE
feat(auth): port logout system to new backend structure

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   UnauthorizedException,
   Get,
   Param,
+  UseGuards,
 } from '@nestjs/common';
 import type { Request } from 'express';
 import { AuthService } from './auth.service';
@@ -14,6 +15,8 @@ import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { LoginDto } from './dto/login.dto';
 import { NonceProvider } from './providers/nonce.provider';
 import { NonceParamDto } from './dto/nonce-param.dto';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { JwtPayload } from './interfaces/jwt-payload.interface';
 
 @Controller('auth')
 export class AuthController {
@@ -70,6 +73,48 @@ export class AuthController {
     }
 
     return this.authService.refresh(body.refreshToken, {
+      ipAddress: this.getIpAddress(request),
+      userAgent: request.headers['user-agent'] ?? null,
+      deviceFingerprint: this.getDeviceFingerprint(request),
+    });
+  }
+
+  @Post('logout')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(200)
+  async logout(@Req() request: Request) {
+    const authHeader = request.headers['authorization'];
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Missing Bearer token');
+    }
+
+    const accessToken = authHeader.slice(7);
+    const user = (request as Request & { user?: JwtPayload }).user;
+
+    if (!user?.sub) {
+      throw new UnauthorizedException('Invalid token payload');
+    }
+
+    await this.authService.logoutUser(accessToken, user.sub, {
+      ipAddress: this.getIpAddress(request),
+      userAgent: request.headers['user-agent'] ?? null,
+      deviceFingerprint: this.getDeviceFingerprint(request),
+    });
+
+    return { message: 'Logout successful' };
+  }
+
+  @Post('logout-all')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(200)
+  async logoutAll(@Req() request: Request) {
+    const user = (request as Request & { user?: JwtPayload }).user;
+
+    if (!user?.sub) {
+      throw new UnauthorizedException('Invalid token payload');
+    }
+
+    return this.authService.logoutAllSessions(user.sub, {
       ipAddress: this.getIpAddress(request),
       userAgent: request.headers['user-agent'] ?? null,
       deviceFingerprint: this.getDeviceFingerprint(request),

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -11,6 +11,7 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RolesGuard } from './guards/roles.guard';
 import { NonceProvider } from './providers/nonce.provider';
 import { SuspensionService } from './suspension.service';
+import { RedisModule } from '../redis/redis.module';
 
 import { AuditLog } from './entities/audit-log.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
@@ -19,7 +20,10 @@ import { Role } from '../users/entities/role.entity';
 import { UserSuspension } from '../users/entities/user-suspension.entity';
 
 @Module({
-  imports: [, UserSuspension]),
+  imports: [
+    ConfigModule,
+    TypeOrmModule.forFeature([AuditLog, RefreshToken, User, Role, UserSuspension]),
+    RedisModule,
   ],
   controllers: [AuthController, AuditLogsController],
   providers: [
@@ -31,8 +35,6 @@ import { UserSuspension } from '../users/entities/user-suspension.entity';
     NonceProvider,
     SuspensionService,
   ],
-  exports: [AuthService, AuditLogService, JwtAuthGuard, RolesGuard, SuspensionService
-  ],
-  exports: [AuthService, JwtAuthGuard, RolesGuard],
+  exports: [AuthService, AuditLogService, JwtAuthGuard, RolesGuard, SuspensionService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -2,12 +2,13 @@ import { ForbiddenException, Injectable, Logger, UnauthorizedException } from '@
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { createHmac, randomUUID, timingSafeEqual } from 'crypto';
-import { DataSource, EntityManager, IsNull, Repository } from 'typeorm';
+import { DataSource, EntityManager, IsNull, Not, Repository } from 'typeorm';
 import { AuditLogService, RequestAudit } from './audit-log.service';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { SuspensionService } from './suspension.service';
 import { User } from '../users/entities/user.entity';
 import { Role } from '../users/entities/role.entity';
+import { RedisService } from '../redis/redis.service';
 import * as StellarSDK from 'stellar-sdk';
 import { verify } from 'stellar-sdk';
 
@@ -34,6 +35,8 @@ const JWT_RESERVED_CLAIMS = new Set(['iat', 'exp', 'nbf', 'jti', 'typ']);
 export class AuthService {
   private readonly logger = new Logger(AuthService.name);
 
+  private readonly TOKEN_BLACKLIST_PREFIX = 'blacklist:token';
+
   constructor(
     @InjectRepository(RefreshToken)
     private readonly refreshTokenRepository: Repository<RefreshToken>,
@@ -41,6 +44,7 @@ export class AuthService {
     private readonly configService: ConfigService,
     private readonly auditLogService: AuditLogService,
     private readonly suspensionService: SuspensionService,
+    private readonly redisService: RedisService,
   ) {}
 
   verifyStellarSignature(walletAddress: string, nonce: string, signature: string): boolean {
@@ -305,6 +309,109 @@ export class AuthService {
       assignedByUserId,
       audit,
     });
+  }
+
+  /**
+   * Logout current session:
+   * - Blacklists the access token JTI in Redis until natural expiration
+   * - Revokes all refresh tokens for the user in the database
+   * - Records logout event in audit log
+   */
+  async logoutUser(
+    accessToken: string,
+    userId: string,
+    audit: RequestAudit,
+  ): Promise<void> {
+    // Decode token to get jti and exp (no verify needed — guard already did that)
+    const parts = accessToken.split('.');
+    if (parts.length === 3) {
+      try {
+        const payload = JSON.parse(
+          Buffer.from(parts[1], 'base64url').toString('utf8'),
+        ) as { jti?: string; exp?: number };
+
+        if (payload.jti && payload.exp) {
+          const ttlSeconds = Math.max(
+            Math.ceil(payload.exp - Date.now() / 1000),
+            1,
+          );
+          await this.redisService.set(
+            `${this.TOKEN_BLACKLIST_PREFIX}:${payload.jti}`,
+            'blacklisted',
+            ttlSeconds,
+          );
+        }
+      } catch {
+        // Non-fatal — token will expire naturally
+        this.logger.warn(`Could not decode access token for blacklisting (userId: ${userId})`);
+      }
+    }
+
+    // Revoke all refresh tokens for this user
+    await this.refreshTokenRepository.update(
+      { userId, revokedAt: IsNull() },
+      { revokedAt: new Date() },
+    );
+
+    // Audit log
+    await this.auditLogService.logLogout({ userId, audit });
+
+    this.logger.log(`User logged out: ${userId}`);
+  }
+
+  /**
+   * Logout all sessions (token versioning):
+   * - Increments tokenVersion to immediately invalidate all existing JWTs
+   * - Revokes all refresh tokens in the database
+   * - Records audit event
+   */
+  async logoutAllSessions(
+    userId: string,
+    audit: RequestAudit,
+  ): Promise<{ message: string; revokedCount: number }> {
+    const user = await this.dataSource.manager.findOne(User, {
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    // Increment token version — invalidates all existing access tokens
+    user.tokenVersion += 1;
+    await this.dataSource.manager.save(User, user);
+
+    // Revoke all active refresh tokens
+    const result = await this.refreshTokenRepository
+      .createQueryBuilder()
+      .update()
+      .set({ revokedAt: new Date() })
+      .where('userId = :userId AND revokedAt IS NULL', { userId })
+      .execute();
+
+    const revokedCount = result.affected ?? 0;
+
+    // Audit log — treat as password-equivalent change
+    await this.auditLogService.logPasswordEquivalentChange(userId, audit, {
+      reason: 'logout_all_sessions',
+      revokedCount,
+      newTokenVersion: user.tokenVersion,
+    });
+
+    this.logger.log(`All sessions revoked for user: ${userId} (${revokedCount} tokens)`);
+
+    return { message: 'All sessions revoked successfully', revokedCount };
+  }
+
+  /**
+   * Check if an access token JTI is blacklisted in Redis.
+   * Used by the JWT guard.
+   */
+  async isTokenBlacklisted(jti: string): Promise<boolean> {
+    const value = await this.redisService.get(
+      `${this.TOKEN_BLACKLIST_PREFIX}:${jti}`,
+    );
+    return value !== null;
   }
 
   private async handleRefreshTokenReuse(

--- a/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.ts
@@ -9,12 +9,16 @@ import { ConfigService } from '@nestjs/config';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { JwtPayload } from '../interfaces/jwt-payload.interface';
 import { SuspensionService } from '../suspension.service';
+import { RedisService } from '../../redis/redis.service';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
+  private readonly TOKEN_BLACKLIST_PREFIX = 'blacklist:token';
+
   constructor(
     private readonly configService: ConfigService,
     private readonly suspensionService: SuspensionService,
+    private readonly redisService: RedisService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -30,6 +34,16 @@ export class JwtAuthGuard implements CanActivate {
 
     const token = authorization.slice(7).trim();
     const payload = this.verifyAccessToken(token);
+
+    // Check Redis blacklist — rejects tokens invalidated by logout
+    if (payload.jti) {
+      const blacklistKey = `${this.TOKEN_BLACKLIST_PREFIX}:${payload.jti}`;
+      const isBlacklisted = await this.redisService.get(blacklistKey);
+      if (isBlacklisted !== null) {
+        throw new UnauthorizedException('Token has been revoked');
+      }
+    }
+
     const suspension = await this.suspensionService.getActiveSuspension(payload.sub);
     if (suspension) {
       const untilText = suspension.suspendedUntil


### PR DESCRIPTION
closes #463 
POST /auth/logout: blacklists access token JTI in Redis with TTL matching token expiration, revokes all refresh tokens in DB, records audit log
- POST /auth/logout-all: increments tokenVersion to invalidate all JWTs across all devices, revokes all refresh tokens, records audit log
- JwtAuthGuard: checks Redis blacklist before allowing access, rejects blacklisted tokens with 401
- AuthModule: added RedisModule import, fixed broken imports/exports, added all required providers
- AuthService: injected RedisService, added logoutUser(), logoutAllSessions(), isTokenBlacklisted()