### PR TITLE
feat: add dispute and timeout error codes (500-503)

### DIFF
--- a/contracts/src/dispute_error.rs
+++ b/contracts/src/dispute_error.rs
@@ -1,0 +1,21 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum DisputeError {
+    /// Cannot auto-refund yet
+    DisputeWindowNotElapsed = 500,
+    /// Dispute already exists for session
+    DisputeAlreadyOpen = 501,
+    /// No open dispute to resolve
+    DisputeNotOpen = 502,
+    /// Session not eligible for resolution
+    ResolutionNotAllowed = 503,
+}
+
+impl From<DisputeError> for u32 {
+    fn from(error: DisputeError) -> Self {
+        error as u32
+    }
+}

--- a/src/common/exceptions/error-codes.enum.ts
+++ b/src/common/exceptions/error-codes.enum.ts
@@ -5,6 +5,10 @@ export enum ErrorCodes {
   NOT_ADMIN = 201, // Caller is not contract admin
   NOT_BUYER = 202, // Caller is not session buyer
   NOT_SELLER = 203, // Caller is not session seller
+  DISPUTE_WINDOW_NOT_ELAPSED = 500, // Cannot auto-refund yet
+  DISPUTE_ALREADY_OPEN = 501, // Dispute already exists for session
+  DISPUTE_NOT_OPEN = 502, // No open dispute to resolve
+  RESOLUTION_NOT_ALLOWED = 503, // Session not eligible for resolution
   FORBIDDEN = 'FORBIDDEN',
   BAD_REQUEST = 'BAD_REQUEST',
   INTERNAL_ERROR = 'INTERNAL_ERROR',


### PR DESCRIPTION
Closes #560

---

## Summary
Adds dispute/timeout error codes as a dedicated Rust enum and extends the TypeScript error codes enum.

## Changes
- `contracts/src/dispute_error.rs` — new `DisputeError` enum
- `src/common/exceptions/error-codes.enum.ts` — added dispute error codes

## Error Codes
| Code | Name | Description |
|------|------|-------------|
| 500 | `DisputeWindowNotElapsed` | Cannot auto-refund yet |
| 501 | `DisputeAlreadyOpen` | Dispute already exists for session |
| 502 | `DisputeNotOpen` | No open dispute to resolve |
| 503 | `ResolutionNotAllowed` | Session not eligible for resolution |

## Labels
`error-handling` `dispute` `timeout`