### PR TITLE
Feat/maximum session duration enforcement

### DIFF
--- a/contracts/escrow/src/expiry.rs
+++ b/contracts/escrow/src/expiry.rs
@@ -1,0 +1,215 @@
+// ============================================================================
+// expiry.rs — Issue: Session Expiry / Auto-Cancellation
+//
+// Prevents sessions from staying in `Locked` state indefinitely by enforcing
+// a maximum lifetime. After `max_session_duration_ledgers` ledgers have
+// passed since `lock_funds`, anyone can call `cancel_expired_session` to
+// refund the buyer fully (no fee deducted).
+//
+// Storage layout (all persistent):
+//   ExpiryConfig          → ExpiryConfig struct (admin-set)
+//   SessionExpiry(id)     → u32 ledger sequence at which session expires
+//
+// Integration with main lib.rs:
+//   1. `lock_funds` must call `expiry::record_expiry(&env, &session_id)` after
+//      creating the session.
+//   2. `approve_session` / `complete_session` must call
+//      `expiry::assert_not_expired(&env, &session_id)` before proceeding.
+//   3. Expose `cancel_expired_session` as a top-level entry point.
+// ============================================================================
+
+use soroban_sdk::{contracttype, token, Address, BytesN, Env, Symbol};
+
+use crate::{reentrancy, Bytes32, SessionData, SkillSyncEscrow, SkillSyncKey, Status};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Admin-configurable expiry parameters.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ExpiryConfig {
+    /// Maximum ledgers a session may stay in `Locked` state.
+    /// Default: 30_000 ledgers ≈ 7 days (at ~20 seconds/ledger on Stellar mainnet).
+    pub max_session_duration_ledgers: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+pub enum ExpiryKey {
+    /// Global expiry configuration.
+    Config,
+    /// Stores the ledger sequence at which `session_id` expires.
+    SessionExpiry(Bytes32),
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Default maximum session lifetime in ledgers (~7 days on Stellar mainnet).
+pub const DEFAULT_MAX_SESSION_DURATION: u32 = 30_000;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn get_config(env: &Env) -> ExpiryConfig {
+    env.storage()
+        .persistent()
+        .get(&ExpiryKey::Config)
+        .unwrap_or(ExpiryConfig {
+            max_session_duration_ledgers: DEFAULT_MAX_SESSION_DURATION,
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Admin API
+// ---------------------------------------------------------------------------
+
+/// Admin configures the maximum session lifetime.
+///
+/// # Parameters
+/// - `max_duration` — ledgers before a Locked session auto-expires (must be > 0)
+pub fn set_max_session_duration(env: &Env, max_duration: u32) {
+    assert!(max_duration > 0, "max_duration must be > 0");
+
+    env.storage().persistent().set(
+        &ExpiryKey::Config,
+        &ExpiryConfig {
+            max_session_duration_ledgers: max_duration,
+        },
+    );
+
+    env.events().publish(
+        (Symbol::new(env, "MaxSessionDurationSet"),),
+        max_duration,
+    );
+}
+
+/// Returns the current expiry configuration.
+pub fn get_expiry_config(env: &Env) -> ExpiryConfig {
+    get_config(env)
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle hooks (called from main lib.rs)
+// ---------------------------------------------------------------------------
+
+/// Record the expiry ledger for a newly locked session.
+///
+/// Must be called inside `lock_funds` immediately after the session is saved.
+/// Stores `expires_at = current_ledger + max_session_duration_ledgers`.
+pub fn record_expiry(env: &Env, session_id: &Bytes32) {
+    let config = get_config(env);
+    let expires_at = env
+        .ledger()
+        .sequence()
+        .saturating_add(config.max_session_duration_ledgers);
+
+    env.storage()
+        .persistent()
+        .set(&ExpiryKey::SessionExpiry(session_id.clone()), &expires_at);
+}
+
+/// Returns the ledger at which `session_id` expires (0 if not recorded).
+pub fn get_expiry_ledger(env: &Env, session_id: &Bytes32) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&ExpiryKey::SessionExpiry(session_id.clone()))
+        .unwrap_or(0)
+}
+
+/// Returns `true` if the session has passed its expiry ledger.
+pub fn is_expired(env: &Env, session_id: &Bytes32) -> bool {
+    let expires_at = get_expiry_ledger(env, session_id);
+    if expires_at == 0 {
+        return false; // no expiry recorded — treat as non-expiring
+    }
+    env.ledger().sequence() > expires_at
+}
+
+/// Assert that the session has NOT expired.
+///
+/// Call this at the top of `approve_session`, `complete_session`, and any
+/// other state-advancing function that should be blocked post-expiry.
+/// Panics with `SessionExpired` if the session is past its expiry ledger.
+pub fn assert_not_expired(env: &Env, session_id: &Bytes32) {
+    if is_expired(env, session_id) {
+        panic!(
+            "SessionExpired: session {} has passed its expiry ledger",
+            env.ledger().sequence()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public: cancel_expired_session
+// ---------------------------------------------------------------------------
+
+/// Anyone can call this to cancel and refund a session that has exceeded its
+/// maximum lifetime while still in `Locked` state.
+///
+/// Behaviour:
+///   • Session must be in `Locked` state (completed/approved/etc. are not cancelable).
+///   • Current ledger must be > expires_at.
+///   • Full amount is refunded to buyer; no platform fee is deducted.
+///   • Emits `SessionExpiredAndCancelled` event.
+///   • Transfer is reentrancy-guarded.
+///
+/// This function reads session data directly from the persistent store that
+/// `SkillSyncEscrow` writes to (same `SkillSyncKey::Session` keys), so no
+/// cross-contract call is needed.
+pub fn cancel_expired_session(env: Env, session_id: Bytes32, token_id: Address) {
+    // Retrieve session from the main SkillSyncEscrow persistent storage
+    let mut session: SessionData = env
+        .storage()
+        .persistent()
+        .get(&SkillSyncKey::Session(session_id.clone()))
+        .expect("session not found");
+
+    // Must be in Locked state
+    assert!(
+        session.status == Status::Locked,
+        "InvalidState: only Locked sessions can be expired-cancelled"
+    );
+
+    // Must be past expiry
+    let expires_at = get_expiry_ledger(&env, &session_id);
+    assert!(expires_at > 0, "no expiry recorded for this session");
+    assert!(
+        env.ledger().sequence() > expires_at,
+        "SessionNotYetExpired: expiry ledger not reached"
+    );
+
+    let amount = session.amount;
+    let buyer = session.buyer.clone();
+
+    // Refund buyer — reentrancy guarded
+    reentrancy::guarded(&env, || {
+        token::Client::new(&env, &token_id).transfer(
+            &env.current_contract_address(),
+            &buyer,
+            &amount,
+        );
+    });
+
+    // Update session state to Refunded
+    session.status = Status::Refunded;
+    env.storage()
+        .persistent()
+        .set(&SkillSyncKey::Session(session_id.clone()), &session);
+
+    // Emit event
+    env.events().publish(
+        (
+            Symbol::new(&env, "SessionExpiredAndCancelled"),
+            session_id.clone(),
+        ),
+        (buyer, amount, expires_at, env.ledger().sequence()),
+    );
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,160 +1,1025 @@
 #![no_std]
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, IntoVal,
+    String, Symbol, Vec,
+};
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes32, Env, Symbol, String};
+// ============================================================================
+// New feature modules
+// ============================================================================
 
-#[contract]
-pub struct EscrowContract;
+/// Issue: Non-reentrant guard (error 700)
+pub mod reentrancy;
+
+/// Issue: Milestone-based escrow
+pub mod milestone;
+
+/// Issue: Rate limiting / anti-DoS
+pub mod rate_limit;
+
+/// Issue: Session expiry / auto-cancellation
+pub mod expiry;
+
+// ============================================================================
+// Single Session Escrow Contract (Contract)
+// ============================================================================
 
 #[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Session {
-    pub id: Bytes32,
-    pub buyer: Address,
-    pub seller: Address,
-    pub amount: i128,
-    pub timestamp: u64,
-    pub status: u32,
-    pub completed_at: u64,
-    pub dispute_opened_at: u64,
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum SingleSessionState {
+    Pending,
+    Locked,
+    Completed,
+    Disputed,
+    Refunded,
 }
+
+#[contract]
+pub struct Contract;
+
+#[contractimpl]
+impl Contract {
+    pub fn init(env: Env, buyer: Address, seller: Address, amount: i128) {
+        env.storage().instance().set(&symbol_short!("buyer"), &buyer);
+        env.storage().instance().set(&symbol_short!("seller"), &seller);
+        env.storage().instance().set(&symbol_short!("amount"), &amount);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("state"), &SingleSessionState::Pending);
+    }
+
+    pub fn lock(env: Env) {
+        let buyer: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("buyer"))
+            .unwrap();
+        buyer.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("state"), &SingleSessionState::Locked);
+    }
+
+    pub fn complete(env: Env) {
+        let buyer: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("buyer"))
+            .unwrap();
+        buyer.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("state"), &SingleSessionState::Completed);
+    }
+
+    pub fn approve(env: Env) {
+        let seller: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("seller"))
+            .unwrap();
+        seller.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("state"), &SingleSessionState::Pending);
+    }
+
+    pub fn dispute(env: Env) {
+        let buyer: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("buyer"))
+            .unwrap();
+        buyer.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("state"), &SingleSessionState::Disputed);
+    }
+
+    pub fn resolve(env: Env, admin: Address, _buyer_pct: u32) {
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("state"), &SingleSessionState::Refunded);
+    }
+
+    pub fn refund(env: Env) {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("state"), &SingleSessionState::Refunded);
+    }
+
+    pub fn get_state(env: Env) -> SingleSessionState {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("state"))
+            .unwrap_or(SingleSessionState::Pending)
+    }
+}
+
+// ============================================================================
+// Multi Session Escrow Contract (EscrowContract)
+// ============================================================================
+
+pub const DISPUTE_WINDOW: u64 = 7 * 24 * 3600; // 7 days
+const BPS_DENOMINATOR: i128 = 10_000;
+const TREASURY_KEY: Symbol = symbol_short!("TREASURY");
 
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
-    Session(Bytes32),
+    Session(u64),
     Admin,
+    PlatformFee,
     Treasury,
-    FeeBps,
     DisputeWindow,
 }
 
-const STATUS_LOCKED: u32 = 0;
-const STATUS_COMPLETED: u32 = 1;
-const STATUS_DISPUTED: u32 = 2;
-const STATUS_REFUNDED: u32 = 3;
-const STATUS_RESOLVED: u32 = 4;
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub enum SessionState {
+    Locked,
+    Completed,
+    Approved,
+    Refunded,
+    AutoRefunded,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Session {
+    pub buyer: Address,
+    pub seller: Address,
+    pub amount: i128,
+    pub state: SessionState,
+    pub completed_at: u64,
+}
+
+/// Result of splitting a session payment into seller and treasury portions.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeSplit {
+    pub seller_amount: i128,
+    pub treasury_amount: i128,
+}
+
+#[contract]
+pub struct EscrowContract;
 
 #[contractimpl]
 impl EscrowContract {
-    pub fn init_config(e: Env, admin: Address, treasury: Address, fee_bps: u32, dispute_window: u64) {
+    pub fn initialize(env: Env, admin: Address, treasury: Address, dispute_window: u32) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Treasury, &treasury);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PlatformFee, &0_u32);
+        env.storage()
+            .persistent()
+            .set(&DataKey::DisputeWindow, &dispute_window);
+        env.events().publish(
+            (Symbol::new(&env, "Initialized"),),
+            (admin, treasury, dispute_window),
+        );
+    }
+
+    pub fn set_treasury(env: Env, new_treasury: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
         admin.require_auth();
-        e.storage().persistent().set(&DataKey::Admin, &admin);
-        e.storage().persistent().set(&DataKey::Treasury, &treasury);
-        e.storage().persistent().set(&DataKey::FeeBps, &fee_bps);
-        e.storage().persistent().set(&DataKey::DisputeWindow, &dispute_window);
+        let old_treasury: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Treasury)
+            .expect("treasury not set");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Treasury, &new_treasury);
+        env.events().publish(
+            (Symbol::new(&env, "TreasuryUpdated"),),
+            (old_treasury, new_treasury, admin),
+        );
+    }
+
+    pub fn get_treasury(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Treasury)
+            .expect("treasury not set")
+    }
+
+    pub fn set_platform_fee(env: Env, new_fee_bps: u32) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        if new_fee_bps > 1000 {
+            panic!("fee_bps must not exceed 1000");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::PlatformFee, &new_fee_bps);
+        env.events()
+            .publish((Symbol::new(&env, "PlatformFeeUpdated"),), new_fee_bps);
+    }
+
+    pub fn get_platform_fee(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PlatformFee)
+            .unwrap_or(0_u32)
     }
 
     pub fn lock_funds(
-        e: Env,
+        env: Env,
+        session_id: u64,
+        buyer: Address,
+        seller: Address,
+        amount: i128,
+        token_id: Address,
+    ) {
+        buyer.require_auth();
+        assert!(amount > 0, "amount must be positive");
+        assert!(
+            !env.storage()
+                .persistent()
+                .has(&DataKey::Session(session_id)),
+            "duplicate session"
+        );
+        token::Client::new(&env, &token_id).transfer(
+            &buyer,
+            &env.current_contract_address(),
+            &amount,
+        );
+        env.storage().persistent().set(
+            &DataKey::Session(session_id),
+            &Session {
+                buyer,
+                seller,
+                amount,
+                state: SessionState::Locked,
+                completed_at: 0,
+            },
+        );
+        env.events()
+            .publish((symbol_short!("LOCKED"), session_id), amount);
+    }
+
+    pub fn complete(env: Env, session_id: u64) {
+        let mut s: Session = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Session(session_id))
+            .unwrap();
+        s.seller.require_auth();
+        assert_eq!(s.state, SessionState::Locked);
+        s.state = SessionState::Completed;
+        s.completed_at = env.ledger().timestamp();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Session(session_id), &s);
+    }
+
+    pub fn approve(env: Env, session_id: u64, token_id: Address) {
+        let mut s: Session = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Session(session_id))
+            .unwrap();
+        s.buyer.require_auth();
+        assert_eq!(s.state, SessionState::Completed);
+
+        let fee_bps = Self::get_platform_fee(env.clone());
+        let fee = s.amount * fee_bps as i128 / 10_000;
+        let payout = s.amount - fee;
+
+        let t = token::Client::new(&env, &token_id);
+        t.transfer(&env.current_contract_address(), &s.seller, &payout);
+        if fee > 0 {
+            let treasury = Self::get_treasury(env.clone());
+            t.transfer(&env.current_contract_address(), &treasury, &fee);
+        }
+        s.state = SessionState::Approved;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Session(session_id), &s);
+        env.events()
+            .publish((Symbol::new(&env, "SessionApproved"),), session_id);
+    }
+
+    pub fn approve_session(env: Env, session_id: u64, token_id: Address) {
+        Self::approve(env, session_id, token_id);
+    }
+
+    pub fn refund(env: Env, session_id: u64, token_id: Address) {
+        let mut s: Session = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Session(session_id))
+            .unwrap();
+        s.buyer.require_auth();
+        assert_eq!(s.state, SessionState::Locked);
+        token::Client::new(&env, &token_id).transfer(
+            &env.current_contract_address(),
+            &s.buyer,
+            &s.amount,
+        );
+        s.state = SessionState::Refunded;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Session(session_id), &s);
+        env.events()
+            .publish((symbol_short!("REFUNDED"), session_id), s.amount);
+        env.events()
+            .publish((Symbol::new(&env, "SessionRefunded"),), session_id);
+    }
+
+    pub fn refund_session(env: Env, session_id: u64, token_id: Address) {
+        Self::refund(env, session_id, token_id);
+    }
+
+    pub fn auto_refund(env: Env, session_id: u64, token_id: Address) {
+        let mut s: Session = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Session(session_id))
+            .unwrap();
+        assert_eq!(s.state, SessionState::Completed);
+        assert!(
+            env.ledger().timestamp() >= s.completed_at + DISPUTE_WINDOW,
+            "window not passed"
+        );
+        token::Client::new(&env, &token_id).transfer(
+            &env.current_contract_address(),
+            &s.buyer,
+            &s.amount,
+        );
+        s.state = SessionState::AutoRefunded;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Session(session_id), &s);
+        env.events()
+            .publish((symbol_short!("AUTOREF"), session_id), s.amount);
+    }
+
+    pub fn get_session(env: Env, session_id: u64) -> Session {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Session(session_id))
+            .unwrap()
+    }
+
+    pub fn calculate_fee(amount: i128, fee_bps: u32) -> FeeSplit {
+        if amount < 0 {
+            panic!("amount must be non-negative");
+        }
+        if (fee_bps as i128) > BPS_DENOMINATOR {
+            panic!("fee_bps must not exceed 10000");
+        }
+
+        let treasury_amount = amount
+            .checked_mul(fee_bps as i128)
+            .expect("fee multiplication overflow")
+            / BPS_DENOMINATOR;
+        let seller_amount = amount - treasury_amount;
+
+        FeeSplit {
+            seller_amount,
+            treasury_amount,
+        }
+    }
+
+    pub fn settle_session(env: Env, amount: i128, fee_bps: u32) -> FeeSplit {
+        let split = Self::calculate_fee(amount, fee_bps);
+        let current: i128 = env
+            .storage()
+            .instance()
+            .get(&TREASURY_KEY)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&TREASURY_KEY, &(current + split.treasury_amount));
+        split
+    }
+
+    pub fn treasury_balance(env: Env) -> i128 {
+        env.storage().instance().get(&TREASURY_KEY).unwrap_or(0)
+    }
+}
+
+// ============================================================================
+// SkillSync Escrow Contract — original issues + new issues integrated
+// ============================================================================
+
+pub type Bytes32 = BytesN<32>;
+
+/// Session status enum
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub enum Status {
+    Locked,
+    Completed,
+    Approved,
+    Refunded,
+    Disputed,
+    Resolved,
+    AutoRefunded,
+}
+
+/// Session struct
+#[contracttype]
+#[derive(Clone)]
+pub struct SessionData {
+    pub buyer: Address,
+    pub seller: Address,
+    pub amount: i128,
+    pub status: Status,
+    pub created_at: u64,
+    pub completed_at: u64,
+    pub dispute_resolved_at: u64,
+}
+
+#[contracttype]
+pub enum SkillSyncKey {
+    Session(Bytes32),
+    Admin,
+    DisputeWindow,
+    WasmHash,
+}
+
+/// Error codes for SkillSyncEscrow
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[repr(u32)]
+pub enum EscrowError {
+    DuplicateSessionId = 1,
+    SessionNotFound = 2,
+    InvalidState = 3,
+    Unauthorized = 4,
+    // New error codes added for feature issues:
+    ReentrancyDetected = 700,
+    RateLimitExceeded = 800,
+    SessionExpired = 900,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractUpgraded {
+    pub old_wasm_hash: Bytes32,
+    pub new_wasm_hash: Bytes32,
+    pub upgraded_by: Address,
+    pub timestamp: u64,
+}
+
+const DEFAULT_DISPUTE_WINDOW: u32 = 1000;
+
+#[contract]
+pub struct SkillSyncEscrow;
+
+impl SkillSyncEscrow {
+    fn get_session_internal(env: &Env, id: &Bytes32) -> SessionData {
+        env.storage()
+            .persistent()
+            .get(&SkillSyncKey::Session(id.clone()))
+            .expect("session not found")
+    }
+
+    fn save_session_internal(env: &Env, id: &Bytes32, session: &SessionData) {
+        env.storage()
+            .persistent()
+            .set(&SkillSyncKey::Session(id.clone()), session);
+    }
+
+    /// Verify caller is the stored admin.
+    fn require_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&SkillSyncKey::Admin)
+            .expect("not initialized");
+        if caller != &admin {
+            panic!("Unauthorized: caller is not admin");
+        }
+    }
+}
+
+#[contractimpl]
+impl SkillSyncEscrow {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&SkillSyncKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage()
+            .persistent()
+            .set(&SkillSyncKey::Admin, &admin);
+    }
+
+    // ── Session storage helpers ──────────────────────────────────────────────
+
+    pub fn get_session(env: Env, id: Bytes32) -> SessionData {
+        Self::get_session_internal(&env, &id)
+    }
+
+    pub fn save_session(env: Env, id: Bytes32, session: SessionData) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&SkillSyncKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        Self::save_session_internal(&env, &id, &session);
+    }
+
+    // ── lock_funds (integrated: rate limit + reentrancy guard + expiry) ──────
+
+    /// Lock funds into a new escrow session.
+    ///
+    /// New behaviours added:
+    ///   • Rate limit check: buyer cannot exceed max sessions per window.
+    ///   • Token transfer is wrapped in a reentrancy guard.
+    ///   • Expiry ledger is recorded so `cancel_expired_session` can be called
+    ///     if the session stalls in `Locked` state too long.
+    pub fn lock_funds(
+        env: Env,
         session_id: Bytes32,
         buyer: Address,
         seller: Address,
         amount: i128,
+        token_id: Address,
     ) {
         buyer.require_auth();
+        assert!(amount > 0, "amount must be positive");
 
-        let now = e.ledger().timestamp();
+        // ── Issue: Rate limit check ──────────────────────────────────────────
+        // Panics with `RateLimitExceeded` + emits `RateLimitHit` if exceeded.
+        rate_limit::check_and_increment(&env, &buyer);
 
-        let session_metadata = Session {
-            id: session_id.clone(),
+        if env
+            .storage()
+            .persistent()
+            .has(&SkillSyncKey::Session(session_id.clone()))
+        {
+            panic!("DuplicateSessionId");
+        }
+
+        // ── Issue: Reentrancy-guarded token transfer ─────────────────────────
+        reentrancy::guarded(&env, || {
+            token::Client::new(&env, &token_id).transfer(
+                &buyer,
+                &env.current_contract_address(),
+                &amount,
+            );
+        });
+
+        let session = SessionData {
             buyer: buyer.clone(),
-            seller: seller.clone(),
+            seller,
             amount,
-            timestamp: now,
-            status: STATUS_LOCKED,
+            status: Status::Locked,
+            created_at: env.ledger().sequence() as u64,
             completed_at: 0,
-            dispute_opened_at: 0,
+            dispute_resolved_at: 0,
         };
-        e.storage().persistent().set(&DataKey::Session(session_id.clone()), &session_metadata);
+        Self::save_session_internal(&env, &session_id, &session);
 
-        e.events().publish(
-            (Symbol::new(&e, "FundsLocked"),),
-            (session_id, buyer, seller, amount, now),
+        // ── Issue: Record expiry for this session ────────────────────────────
+        expiry::record_expiry(&env, &session_id);
+
+        env.events().publish(
+            (Symbol::new(&env, "FundsLocked"), session_id),
+            amount,
         );
     }
 
-    pub fn complete_session(e: Env, session_id: Bytes32) {
-        let mut session: Session = e
-            .storage()
-            .persistent()
-            .get(&DataKey::Session(session_id.clone()))
-            .unwrap();
-        session.status = STATUS_COMPLETED;
-        session.completed_at = e.ledger().timestamp();
-        e.storage().persistent().set(&DataKey::Session(session_id), &session);
-    }
+    // ── complete_session ─────────────────────────────────────────────────────
 
-    pub fn open_dispute(e: Env, session_id: Bytes32, reason: String) {
-        let mut session: Session = e
-            .storage()
-            .persistent()
-            .get(&DataKey::Session(session_id.clone()))
-            .unwrap();
+    /// Seller marks session as completed.
+    /// Now also guards against expired sessions.
+    pub fn complete_session(env: Env, session_id: Bytes32) {
+        // ── Issue: Block if session has expired ──────────────────────────────
+        expiry::assert_not_expired(&env, &session_id);
 
-        if session.status != STATUS_COMPLETED && session.status != STATUS_LOCKED {
-            panic!("session not disputable");
+        let mut session = Self::get_session_internal(&env, &session_id);
+        session.seller.require_auth();
+        if session.status == Status::Completed {
+            panic!("DuplicateSessionId");
         }
-
-        session.status = STATUS_DISPUTED;
-        session.dispute_opened_at = e.ledger().timestamp();
-        e.storage().persistent().set(&DataKey::Session(session_id.clone()), &session);
-        e.events().publish((Symbol::new(&e, "DisputeOpened"),), (session_id, reason));
+        assert!(
+            session.status == Status::Locked,
+            "InvalidState: session must be Locked"
+        );
+        session.status = Status::Completed;
+        session.completed_at = env.ledger().timestamp();
+        Self::save_session_internal(&env, &session_id, &session);
+        env.events().publish(
+            (Symbol::new(&env, "SessionCompleted"), session_id),
+            (session.seller.clone(), session.completed_at),
+        );
     }
 
-    pub fn resolve_dispute(
-        e: Env,
+    // ── dispute_session ──────────────────────────────────────────────────────
+
+    pub fn dispute_session(
+        env: Env,
         session_id: Bytes32,
-        resolution: u32,
-        buyer_share: i128,
-        seller_share: i128,
+        opened_by: Address,
+        reason: soroban_sdk::String,
     ) {
-        let mut session: Session = e
+        let mut session = Self::get_session_internal(&env, &session_id);
+
+        opened_by.require_auth();
+        assert!(
+            opened_by == session.buyer || opened_by == session.seller,
+            "Unauthorized: must be buyer or seller"
+        );
+        assert!(
+            session.status == Status::Locked || session.status == Status::Completed,
+            "InvalidState: session must be Locked or Completed"
+        );
+
+        session.status = Status::Disputed;
+        Self::save_session_internal(&env, &session_id, &session);
+
+        env.events().publish(
+            (Symbol::new(&env, "DisputeOpened"), session_id.clone()),
+            (opened_by, reason, env.ledger().timestamp()),
+        );
+    }
+
+    // ── approve_session (reentrancy-guarded) ─────────────────────────────────
+
+    /// Buyer approves completed session, releasing funds to seller.
+    ///
+    /// Issue: Token transfer is now wrapped in a reentrancy guard.
+    /// Issue: Blocked if session has expired (expiry check).
+    pub fn approve_session(env: Env, session_id: Bytes32, token_id: Address) {
+        // ── Issue: Block if expired ──────────────────────────────────────────
+        expiry::assert_not_expired(&env, &session_id);
+
+        let mut session = Self::get_session_internal(&env, &session_id);
+        session.buyer.require_auth();
+        assert!(
+            session.status == Status::Completed,
+            "InvalidState: session must be Completed"
+        );
+
+        let amount = session.amount;
+        let seller = session.seller.clone();
+        let buyer = session.buyer.clone();
+
+        // ── Issue: Reentrancy-guarded payout ─────────────────────────────────
+        reentrancy::guarded(&env, || {
+            token::Client::new(&env, &token_id).transfer(
+                &env.current_contract_address(),
+                &seller,
+                &amount,
+            );
+        });
+
+        session.status = Status::Approved;
+        Self::save_session_internal(&env, &session_id, &session);
+        env.events().publish(
+            (Symbol::new(&env, "SessionApproved"), session_id),
+            (
+                buyer,
+                seller,
+                amount,
+                0_i128, // fee = 0 in SkillSyncEscrow
+                env.ledger().timestamp(),
+            ),
+        );
+    }
+
+    // ── refund_session (reentrancy-guarded) ──────────────────────────────────
+
+    /// Buyer requests refund. Session must be Locked.
+    ///
+    /// Issue: Token transfer is now wrapped in a reentrancy guard.
+    pub fn refund_session(env: Env, session_id: Bytes32, token_id: Address) {
+        let mut session = Self::get_session_internal(&env, &session_id);
+        session.buyer.require_auth();
+        if session.status == Status::Refunded {
+            panic!("DuplicateSessionId");
+        }
+        assert!(
+            session.status == Status::Locked,
+            "InvalidState: session must be Locked"
+        );
+
+        let amount = session.amount;
+        let buyer = session.buyer.clone();
+
+        // ── Issue: Reentrancy-guarded refund ─────────────────────────────────
+        reentrancy::guarded(&env, || {
+            token::Client::new(&env, &token_id).transfer(
+                &env.current_contract_address(),
+                &buyer,
+                &amount,
+            );
+        });
+
+        session.status = Status::Refunded;
+        Self::save_session_internal(&env, &session_id, &session);
+        env.events().publish(
+            (Symbol::new(&env, "SessionRefunded"), session_id),
+            (buyer, amount, env.ledger().timestamp()),
+        );
+    }
+
+    // ── resolve_dispute (reentrancy-guarded) ─────────────────────────────────
+
+    /// Admin resolves a disputed session, splitting funds between buyer and seller.
+    ///
+    /// Issue: Both token transfers (buyer + seller portions) are wrapped in
+    /// a single reentrancy guard block.
+    ///
+    /// # Parameters
+    /// - `buyer_bps` — percentage of session amount (BPS) sent to buyer;
+    ///                 remainder goes to seller.
+    pub fn resolve_dispute(
+        env: Env,
+        session_id: Bytes32,
+        admin: Address,
+        buyer_bps: u32,
+        token_id: Address,
+    ) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+
+        assert!(buyer_bps <= 10_000, "buyer_bps cannot exceed 10000");
+
+        let mut session = Self::get_session_internal(&env, &session_id);
+        assert!(
+            session.status == Status::Disputed,
+            "InvalidState: session must be Disputed"
+        );
+
+        let buyer_amount = session.amount * buyer_bps as i128 / 10_000;
+        let seller_amount = session.amount - buyer_amount;
+
+        let buyer = session.buyer.clone();
+        let seller = session.seller.clone();
+
+        // ── Issue: Reentrancy-guarded dual payout ────────────────────────────
+        reentrancy::guarded(&env, || {
+            let t = token::Client::new(&env, &token_id);
+            if buyer_amount > 0 {
+                t.transfer(&env.current_contract_address(), &buyer, &buyer_amount);
+            }
+            if seller_amount > 0 {
+                t.transfer(&env.current_contract_address(), &seller, &seller_amount);
+            }
+        });
+
+        session.status = Status::Resolved;
+        session.dispute_resolved_at = env.ledger().timestamp();
+        Self::save_session_internal(&env, &session_id, &session);
+
+        env.events().publish(
+            (Symbol::new(&env, "DisputeResolved"), session_id),
+            (admin, buyer_bps, buyer_amount, seller_amount),
+        );
+    }
+
+    // ── auto_refund ──────────────────────────────────────────────────────────
+
+    pub fn auto_refund(env: Env, session_id: Bytes32, token_id: Address) {
+        let mut session = Self::get_session_internal(&env, &session_id);
+        assert!(
+            session.status == Status::Completed,
+            "InvalidState: session must be Completed"
+        );
+
+        let dispute_window = Self::get_dispute_window(env.clone());
+        let current_timestamp = env.ledger().timestamp();
+        assert!(
+            current_timestamp >= session.completed_at + dispute_window as u64,
+            "DisputeWindowNotPassed: refund window has not expired"
+        );
+
+        let buyer = session.buyer.clone();
+        let amount = session.amount;
+
+        // ── Issue: Reentrancy-guarded auto-refund ────────────────────────────
+        reentrancy::guarded(&env, || {
+            token::Client::new(&env, &token_id).transfer(
+                &env.current_contract_address(),
+                &buyer,
+                &amount,
+            );
+        });
+
+        session.status = Status::AutoRefunded;
+        Self::save_session_internal(&env, &session_id, &session);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "AutoRefundExecuted"),
+                session_id.clone(),
+                session.buyer.clone(),
+            ),
+            (amount, session.completed_at, current_timestamp),
+        );
+    }
+
+    // ── Issue: cancel_expired_session (anyone can call) ──────────────────────
+
+    /// Cancel a session that has been in `Locked` state past its expiry ledger.
+    /// Refunds buyer in full with no fee. Anyone can call this function.
+    ///
+    /// Emits `SessionExpiredAndCancelled`.
+    pub fn cancel_expired_session(env: Env, session_id: Bytes32, token_id: Address) {
+        expiry::cancel_expired_session(env, session_id, token_id);
+    }
+
+    // ── Issue: Admin — rate limit configuration ──────────────────────────────
+
+    /// Admin sets the rate limit for session creation.
+    ///
+    /// # Parameters
+    /// - `max_sessions`   — max sessions per address per window
+    /// - `window_ledgers` — window length in ledger sequences
+    pub fn set_rate_limit(env: Env, admin: Address, max_sessions: u32, window_ledgers: u32) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        rate_limit::set_rate_limit(&env, max_sessions, window_ledgers);
+    }
+
+    /// Admin whitelists an address (bypasses rate limits).
+    pub fn whitelist_address(env: Env, admin: Address, address: Address) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        rate_limit::whitelist_address(&env, &address);
+    }
+
+    /// Admin removes an address from the whitelist.
+    pub fn remove_from_whitelist(env: Env, admin: Address, address: Address) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        rate_limit::remove_from_whitelist(&env, &address);
+    }
+
+    /// Returns the current session count for an address in the active window.
+    pub fn get_user_session_count(env: Env, address: Address) -> u32 {
+        rate_limit::get_user_session_count(&env, &address)
+    }
+
+    // ── Issue: Admin — session expiry configuration ──────────────────────────
+
+    /// Admin configures the maximum session lifetime in ledgers.
+    /// Default is 30_000 ledgers (~7 days on Stellar mainnet).
+    pub fn set_max_session_duration(env: Env, admin: Address, max_duration_ledgers: u32) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        expiry::set_max_session_duration(&env, max_duration_ledgers);
+    }
+
+    /// Returns the ledger at which a session expires (0 if not recorded).
+    pub fn get_session_expiry(env: Env, session_id: Bytes32) -> u32 {
+        expiry::get_expiry_ledger(&env, &session_id)
+    }
+
+    /// Returns whether a session has passed its expiry ledger.
+    pub fn is_session_expired(env: Env, session_id: Bytes32) -> bool {
+        expiry::is_expired(&env, &session_id)
+    }
+
+    // ── Issue: Milestone escrow entry points ─────────────────────────────────
+
+    /// Lock funds for a milestone-based escrow session.
+    ///
+    /// `milestones` is a list of `(percentage_bps, description)` pairs that
+    /// must sum to exactly 10_000 BPS.
+    pub fn lock_funds_with_milestones(
+        env: Env,
+        session_id: Bytes32,
+        buyer: Address,
+        seller: Address,
+        total_amount: i128,
+        token_id: Address,
+        milestones: Vec<(u32, soroban_sdk::String)>,
+    ) {
+        // Rate limit applies to milestone sessions too
+        rate_limit::check_and_increment(&env, &buyer);
+
+        milestone::lock_funds_with_milestones(
+            env,
+            session_id,
+            buyer,
+            seller,
+            total_amount,
+            token_id,
+            milestones,
+        );
+    }
+
+    /// Buyer releases a specific milestone, transferring its share to the seller.
+    pub fn release_milestone(
+        env: Env,
+        session_id: Bytes32,
+        buyer: Address,
+        milestone_index: u32,
+    ) {
+        milestone::release_milestone(env, session_id, buyer, milestone_index);
+    }
+
+    /// Open a dispute on a milestone session (pauses further milestone releases).
+    pub fn dispute_milestone_session(env: Env, session_id: Bytes32, opened_by: Address) {
+        milestone::dispute_milestone_session(env, session_id, opened_by);
+    }
+
+    /// Admin resolves a disputed milestone session.
+    pub fn resolve_milestone_dispute(
+        env: Env,
+        session_id: Bytes32,
+        admin: Address,
+        buyer_bps: u32,
+    ) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        milestone::resolve_milestone_dispute(env, session_id, admin, buyer_bps);
+    }
+
+    /// Returns milestone session data.
+    pub fn get_milestone_session(
+        env: Env,
+        session_id: Bytes32,
+    ) -> milestone::MilestoneSessionData {
+        milestone::get_milestone_session(env, session_id)
+    }
+
+    /// Returns all milestones for a session.
+    pub fn get_milestones(env: Env, session_id: Bytes32) -> Vec<milestone::Milestone> {
+        milestone::get_milestones_for_session(env, session_id)
+    }
+
+    // ── dispute window ───────────────────────────────────────────────────────
+
+    pub fn set_dispute_window(env: Env, window_ledgers: u32) {
+        let admin: Address = env
             .storage()
             .persistent()
-            .get(&DataKey::Session(session_id.clone()))
-            .unwrap();
-        if session.status != STATUS_DISPUTED {
-            panic!("session not disputed");
-        }
-        let admin: Address = e.storage().persistent().get(&DataKey::Admin).unwrap();
+            .get(&SkillSyncKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        env.storage()
+            .persistent()
+            .set(&SkillSyncKey::DisputeWindow, &window_ledgers);
+        env.events().publish(
+            (Symbol::new(&env, "DisputeWindowUpdated"),),
+            window_ledgers,
+        );
+    }
+
+    pub fn get_dispute_window(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&SkillSyncKey::DisputeWindow)
+            .unwrap_or(DEFAULT_DISPUTE_WINDOW)
+    }
+
+    // ── upgrade ──────────────────────────────────────────────────────────────
+
+    pub fn upgrade(env: Env, new_wasm_hash: Bytes32) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&SkillSyncKey::Admin)
+            .expect("not initialized");
         admin.require_auth();
 
-        if buyer_share + seller_share != session.amount {
-            panic!("invalid shares");
-        }
-        let (seller_after_fee, fee_amount) = Self::apply_fee(&e, seller_share);
-        let buyer_after_fee = buyer_share;
-
-        session.status = STATUS_RESOLVED;
-        e.storage().persistent().set(&DataKey::Session(session_id.clone()), &session);
-        e.events().publish(
-            (Symbol::new(&e, "DisputeResolved"),),
-            (session_id, resolution, buyer_after_fee, seller_after_fee, fee_amount),
-        );
-    }
-
-    pub fn auto_refund(e: Env, session_id: Bytes32) {
-        let mut session: Session = e
+        let old_wasm_hash = env
             .storage()
             .persistent()
-            .get(&DataKey::Session(session_id.clone()))
-            .unwrap();
-        if session.status != STATUS_COMPLETED {
-            panic!("session not completed");
-        }
-        let dispute_window: u64 = e.storage().persistent().get(&DataKey::DisputeWindow).unwrap_or(0);
-        if e.ledger().timestamp() <= session.completed_at + dispute_window {
-            panic!("dispute window not elapsed");
-        }
+            .get::<_, Bytes32>(&SkillSyncKey::WasmHash)
+            .unwrap_or_else(|| BytesN::from_array(&env, &[0; 32]));
 
-        session.status = STATUS_REFUNDED;
-        e.storage().persistent().set(&DataKey::Session(session_id.clone()), &session);
-        e.events().publish((Symbol::new(&e, "AutoRefundExecuted"),), (session_id, session.amount));
-    }
+        env.storage()
+            .persistent()
+            .set(&SkillSyncKey::WasmHash, &new_wasm_hash);
 
-    fn apply_fee(e: &Env, amount: i128) -> (i128, i128) {
-        let fee_bps: u32 = e.storage().persistent().get(&DataKey::FeeBps).unwrap_or(0);
-        let fee = (amount * (fee_bps as i128)) / 10_000;
-        (amount - fee, fee)
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
+
+        let event = ContractUpgraded {
+            old_wasm_hash,
+            new_wasm_hash,
+            upgraded_by: admin,
+            timestamp: env.ledger().timestamp(),
+        };
+
+        env.events()
+            .publish((Symbol::new(&env, "ContractUpgraded"),), event);
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/contracts/escrow/src/milestone.rs
+++ b/contracts/escrow/src/milestone.rs
@@ -1,0 +1,408 @@
+// ============================================================================
+// milestone.rs — Issue: Milestone-Based Escrow
+//
+// Allows complex escrow where funds are released in multiple stages, e.g.:
+//   30% upfront → 40% on delivery → 30% on acceptance
+//
+// Storage layout (all persistent):
+//   MilestoneSession(session_id)  → MilestoneSession struct
+//   Milestones(session_id)        → Vec<Milestone>
+//
+// Key invariants:
+//   • All milestone percentages (in BPS) must sum to exactly 10_000.
+//   • Milestones are released in order; you cannot skip one.
+//   • A disputed session cannot have milestones released until resolved.
+//   • Seller can only withdraw the sum of released-but-unclaimed milestones.
+// ============================================================================
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, vec, Address, BytesN, Env, String,
+    Symbol, Vec,
+};
+
+use crate::{reentrancy, Bytes32};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// State of a milestone session.
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub enum MilestoneSessionState {
+    /// Funds locked, milestones pending release.
+    Active,
+    /// A dispute has been raised; milestone releases are paused.
+    Disputed,
+    /// All milestones released and claimed.
+    Completed,
+    /// Admin resolved a dispute; session closed.
+    Resolved,
+}
+
+/// A single milestone within a session.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Milestone {
+    /// Share of total amount in basis points (1 BPS = 0.01%).
+    /// All milestones in a session must sum to 10_000 BPS.
+    pub percentage_bps: u32,
+    /// Human-readable description, e.g. "Delivery of design mockups".
+    pub description: String,
+    /// Whether the buyer has released this milestone.
+    pub released: bool,
+    /// Ledger sequence at which the buyer released this milestone (0 = not released).
+    pub released_at: u64,
+}
+
+/// Top-level milestone session record stored in contract persistent storage.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MilestoneSessionData {
+    pub buyer: Address,
+    pub seller: Address,
+    /// Total amount locked in escrow (in token's smallest unit).
+    pub total_amount: i128,
+    pub token_id: Address,
+    pub state: MilestoneSessionState,
+    /// Sum of amounts already transferred to the seller.
+    pub claimed_amount: i128,
+    /// Ledger sequence when the session was created.
+    pub created_at: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+pub enum MilestoneKey {
+    /// Stores `MilestoneSessionData` for a given session.
+    Session(Bytes32),
+    /// Stores `Vec<Milestone>` for a given session.
+    Milestones(Bytes32),
+    /// Admin address (shared with the main escrow contract).
+    Admin,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Returns a consistent panic message. Soroban panic messages are strings;
+/// we embed the numeric code so off-chain indexers can parse them.
+fn err(code: u32, msg: &str) -> ! {
+    // e.g. "MilestoneError[3]: InvalidState"
+    panic!("MilestoneError[{}]: {}", code, msg)
+}
+
+// Error codes mirror the main EscrowError enum spacing (800-range to avoid
+// collision with the main contract's 700-range reentrancy code).
+pub const ERR_BPS_SUM: u32 = 801; // milestone BPS do not sum to 10_000
+pub const ERR_EMPTY_MILESTONES: u32 = 802; // no milestones provided
+pub const ERR_DUPLICATE_SESSION: u32 = 803;
+pub const ERR_SESSION_NOT_FOUND: u32 = 804;
+pub const ERR_INVALID_STATE: u32 = 805; // wrong state for the operation
+pub const ERR_UNAUTHORIZED: u32 = 806;
+pub const ERR_MILESTONE_INDEX: u32 = 807; // index out of range
+pub const ERR_ALREADY_RELEASED: u32 = 808;
+pub const ERR_DISPUTED: u32 = 809; // operation blocked by active dispute
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn get_session(env: &Env, id: &Bytes32) -> MilestoneSessionData {
+    env.storage()
+        .persistent()
+        .get(&MilestoneKey::Session(id.clone()))
+        .unwrap_or_else(|| err(ERR_SESSION_NOT_FOUND, "session not found"))
+}
+
+fn save_session(env: &Env, id: &Bytes32, session: &MilestoneSessionData) {
+    env.storage()
+        .persistent()
+        .set(&MilestoneKey::Session(id.clone()), session);
+}
+
+fn get_milestones(env: &Env, id: &Bytes32) -> Vec<Milestone> {
+    env.storage()
+        .persistent()
+        .get(&MilestoneKey::Milestones(id.clone()))
+        .unwrap_or_else(|| err(ERR_SESSION_NOT_FOUND, "milestones not found"))
+}
+
+fn save_milestones(env: &Env, id: &Bytes32, milestones: &Vec<Milestone>) {
+    env.storage()
+        .persistent()
+        .set(&MilestoneKey::Milestones(id.clone()), milestones);
+}
+
+/// Compute the token amount for a milestone given total_amount and its BPS.
+/// Rounds DOWN (seller receives remainder via the last milestone's claim).
+pub fn milestone_amount(total_amount: i128, percentage_bps: u32) -> i128 {
+    total_amount * percentage_bps as i128 / 10_000
+}
+
+// ---------------------------------------------------------------------------
+// Public API (standalone functions used by SkillSyncEscrow impl block)
+// ---------------------------------------------------------------------------
+
+/// Lock funds into a new milestone-based escrow session.
+///
+/// # Parameters
+/// - `session_id`  — unique identifier (Bytes32)
+/// - `buyer`       — address funding the escrow; must sign
+/// - `seller`      — address that will receive released milestones
+/// - `total_amount`— total tokens to lock
+/// - `token_id`    — SEP-41 token contract address
+/// - `milestones`  — list of `(percentage_bps, description)` tuples;
+///                   must sum to exactly 10_000 BPS
+pub fn lock_funds_with_milestones(
+    env: Env,
+    session_id: Bytes32,
+    buyer: Address,
+    seller: Address,
+    total_amount: i128,
+    token_id: Address,
+    milestones: Vec<(u32, String)>,
+) {
+    buyer.require_auth();
+
+    // Validate
+    if milestones.is_empty() {
+        err(ERR_EMPTY_MILESTONES, "milestones cannot be empty");
+    }
+    if env
+        .storage()
+        .persistent()
+        .has(&MilestoneKey::Session(session_id.clone()))
+    {
+        err(ERR_DUPLICATE_SESSION, "duplicate session id");
+    }
+
+    // Validate BPS sum == 10_000
+    let bps_sum: u32 = milestones.iter().map(|(bps, _)| bps).sum();
+    if bps_sum != 10_000 {
+        err(ERR_BPS_SUM, "milestone BPS must sum to 10000");
+    }
+
+    // Transfer total_amount from buyer to contract (guarded against reentrancy)
+    reentrancy::guarded(&env, || {
+        token::Client::new(&env, &token_id).transfer(
+            &buyer,
+            &env.current_contract_address(),
+            &total_amount,
+        );
+    });
+
+    // Persist session
+    let session = MilestoneSessionData {
+        buyer: buyer.clone(),
+        seller: seller.clone(),
+        total_amount,
+        token_id: token_id.clone(),
+        state: MilestoneSessionState::Active,
+        claimed_amount: 0,
+        created_at: env.ledger().sequence() as u64,
+    };
+    save_session(&env, &session_id, &session);
+
+    // Persist milestones
+    let mut milestone_vec: Vec<Milestone> = Vec::new(&env);
+    for (percentage_bps, description) in milestones.iter() {
+        milestone_vec.push_back(Milestone {
+            percentage_bps,
+            description,
+            released: false,
+            released_at: 0,
+        });
+    }
+    save_milestones(&env, &session_id, &milestone_vec);
+
+    env.events().publish(
+        (Symbol::new(&env, "MilestoneFundsLocked"), session_id.clone()),
+        (buyer, seller, total_amount, milestone_vec.len()),
+    );
+}
+
+/// Buyer releases a specific milestone, triggering immediate token transfer
+/// to the seller.
+///
+/// # Parameters
+/// - `session_id`       — identifies the escrow session
+/// - `milestone_index`  — zero-based index into the milestones list
+///
+/// # Rules
+/// - Only the buyer may call this.
+/// - Session must be `Active` (not Disputed/Completed/Resolved).
+/// - The milestone must not already be released.
+/// - Transfer is reentrancy-guarded.
+/// - If this is the last milestone, session state transitions to `Completed`.
+pub fn release_milestone(env: Env, session_id: Bytes32, buyer: Address, milestone_index: u32) {
+    buyer.require_auth();
+
+    let mut session = get_session(&env, &session_id);
+
+    // Auth
+    if buyer != session.buyer {
+        err(ERR_UNAUTHORIZED, "only buyer can release milestones");
+    }
+
+    // State checks
+    if session.state == MilestoneSessionState::Disputed {
+        err(ERR_DISPUTED, "milestone releases paused due to active dispute");
+    }
+    if session.state != MilestoneSessionState::Active {
+        err(ERR_INVALID_STATE, "session is not Active");
+    }
+
+    let mut milestones = get_milestones(&env, &session_id);
+
+    let idx = milestone_index as usize;
+    if idx >= milestones.len() as usize {
+        err(ERR_MILESTONE_INDEX, "milestone index out of range");
+    }
+
+    let mut m = milestones.get(milestone_index).unwrap();
+    if m.released {
+        err(ERR_ALREADY_RELEASED, "milestone already released");
+    }
+
+    // Calculate payout
+    let payout = milestone_amount(session.total_amount, m.percentage_bps);
+
+    // Transfer to seller — reentrancy guarded
+    reentrancy::guarded(&env, || {
+        token::Client::new(&env, &session.token_id).transfer(
+            &env.current_contract_address(),
+            &session.seller,
+            &payout,
+        );
+    });
+
+    // Update milestone
+    m.released = true;
+    m.released_at = env.ledger().sequence() as u64;
+    milestones.set(milestone_index, m);
+    save_milestones(&env, &session_id, &milestones);
+
+    // Update session claimed amount
+    session.claimed_amount += payout;
+
+    // Check if all milestones are now released
+    let all_released = milestones.iter().all(|m| m.released);
+    if all_released {
+        session.state = MilestoneSessionState::Completed;
+    }
+    save_session(&env, &session_id, &session);
+
+    env.events().publish(
+        (
+            Symbol::new(&env, "MilestoneReleased"),
+            session_id.clone(),
+            milestone_index,
+        ),
+        payout,
+    );
+}
+
+/// Raise a dispute on a milestone session (pauses further releases).
+pub fn dispute_milestone_session(env: Env, session_id: Bytes32, opened_by: Address) {
+    opened_by.require_auth();
+
+    let mut session = get_session(&env, &session_id);
+
+    if opened_by != session.buyer && opened_by != session.seller {
+        err(ERR_UNAUTHORIZED, "must be buyer or seller");
+    }
+    if session.state != MilestoneSessionState::Active {
+        err(ERR_INVALID_STATE, "session must be Active to dispute");
+    }
+
+    session.state = MilestoneSessionState::Disputed;
+    save_session(&env, &session_id, &session);
+
+    env.events().publish(
+        (Symbol::new(&env, "MilestoneDisputeOpened"), session_id),
+        opened_by,
+    );
+}
+
+/// Admin resolves a disputed milestone session, splitting remaining funds.
+///
+/// - `buyer_bps` — percentage (BPS) of REMAINING (unreleased) funds sent to buyer.
+/// - Remainder goes to seller.
+pub fn resolve_milestone_dispute(
+    env: Env,
+    session_id: Bytes32,
+    admin: Address,
+    buyer_bps: u32,
+) {
+    admin.require_auth();
+
+    // Verify caller is the stored admin
+    let stored_admin: Address = env
+        .storage()
+        .persistent()
+        .get(&MilestoneKey::Admin)
+        .expect("admin not set");
+    if admin != stored_admin {
+        err(ERR_UNAUTHORIZED, "not admin");
+    }
+
+    if buyer_bps > 10_000 {
+        panic!("buyer_bps cannot exceed 10000");
+    }
+
+    let mut session = get_session(&env, &session_id);
+    if session.state != MilestoneSessionState::Disputed {
+        err(ERR_INVALID_STATE, "session is not Disputed");
+    }
+
+    let remaining = session.total_amount - session.claimed_amount;
+
+    if remaining > 0 {
+        let buyer_amount = remaining * buyer_bps as i128 / 10_000;
+        let seller_amount = remaining - buyer_amount;
+
+        let token = token::Client::new(&env, &session.token_id);
+
+        reentrancy::guarded(&env, || {
+            if buyer_amount > 0 {
+                token.transfer(
+                    &env.current_contract_address(),
+                    &session.buyer,
+                    &buyer_amount,
+                );
+            }
+            if seller_amount > 0 {
+                token.transfer(
+                    &env.current_contract_address(),
+                    &session.seller,
+                    &seller_amount,
+                );
+            }
+        });
+
+        session.claimed_amount = session.total_amount; // fully settled
+    }
+
+    session.state = MilestoneSessionState::Resolved;
+    save_session(&env, &session_id, &session);
+
+    env.events().publish(
+        (Symbol::new(&env, "MilestoneDisputeResolved"), session_id),
+        (admin, buyer_bps),
+    );
+}
+
+/// Read-only: returns milestone session data.
+pub fn get_milestone_session(env: Env, session_id: Bytes32) -> MilestoneSessionData {
+    get_session(&env, &session_id)
+}
+
+/// Read-only: returns all milestones for a session.
+pub fn get_milestones_for_session(env: Env, session_id: Bytes32) -> Vec<Milestone> {
+    get_milestones(&env, &session_id)
+}

--- a/contracts/escrow/src/rate_limit.rs
+++ b/contracts/escrow/src/rate_limit.rs
@@ -1,0 +1,220 @@
+// ============================================================================
+// rate_limit.rs — Issue: Rate Limiting / Anti-DoS
+//
+// Prevents spam or DoS attacks by limiting how many escrow sessions a single
+// address can create within a rolling ledger window.
+//
+// Storage layout (all persistent):
+//   RateLimitConfig              → RateLimitConfig struct (admin-set)
+//   UserWindow(address)          → UserWindowData struct
+//   Whitelist(address)           → bool (true = whitelisted, no limit)
+//
+// Window semantics:
+//   • A "window" is a range of `window_ledgers` ledgers.
+//   • The window is identified by: floor(current_ledger / window_ledgers).
+//   • When a user's stored window_id differs from the current window_id,
+//     their counter resets automatically (no admin action needed).
+//   • Whitelisted addresses bypass all checks.
+// ============================================================================
+
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Admin-configurable rate limit parameters.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RateLimitConfig {
+    /// Maximum sessions allowed per address per window.
+    pub max_sessions: u32,
+    /// Window size in ledger sequences.
+    pub window_ledgers: u32,
+}
+
+/// Per-user sliding-window counter stored in persistent storage.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UserWindowData {
+    /// Identifies which window this counter belongs to.
+    /// Computed as: current_ledger / window_ledgers.
+    pub window_id: u32,
+    /// Number of sessions opened in `window_id`.
+    pub count: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+pub enum RateLimitKey {
+    /// Global rate limit config set by admin.
+    Config,
+    /// Per-address window counter.
+    UserWindow(Address),
+    /// Per-address whitelist flag.
+    Whitelist(Address),
+}
+
+// ---------------------------------------------------------------------------
+// Defaults (used when no config has been set)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_SESSIONS: u32 = 10;
+const DEFAULT_WINDOW_LEDGERS: u32 = 1_000; // ~1000 ledgers ≈ 83 minutes on Stellar
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn get_config(env: &Env) -> RateLimitConfig {
+    env.storage()
+        .persistent()
+        .get(&RateLimitKey::Config)
+        .unwrap_or(RateLimitConfig {
+            max_sessions: DEFAULT_MAX_SESSIONS,
+            window_ledgers: DEFAULT_WINDOW_LEDGERS,
+        })
+}
+
+/// Compute the current window_id for the given ledger sequence.
+fn current_window_id(current_ledger: u32, window_ledgers: u32) -> u32 {
+    current_ledger / window_ledgers
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Admin sets the global rate limit.
+///
+/// # Parameters
+/// - `admin`          — must match the admin stored in main escrow contract
+/// - `max_sessions`   — max sessions per address per window
+/// - `window_ledgers` — window size in ledgers (must be > 0)
+pub fn set_rate_limit(env: &Env, max_sessions: u32, window_ledgers: u32) {
+    assert!(window_ledgers > 0, "window_ledgers must be > 0");
+    assert!(max_sessions > 0, "max_sessions must be > 0");
+
+    let config = RateLimitConfig {
+        max_sessions,
+        window_ledgers,
+    };
+    env.storage()
+        .persistent()
+        .set(&RateLimitKey::Config, &config);
+
+    env.events().publish(
+        (Symbol::new(env, "RateLimitUpdated"),),
+        (max_sessions, window_ledgers),
+    );
+}
+
+/// Admin adds an address to the whitelist (bypasses rate limits).
+pub fn whitelist_address(env: &Env, address: &Address) {
+    env.storage()
+        .persistent()
+        .set(&RateLimitKey::Whitelist(address.clone()), &true);
+
+    env.events().publish(
+        (Symbol::new(env, "AddressWhitelisted"),),
+        address.clone(),
+    );
+}
+
+/// Admin removes an address from the whitelist.
+pub fn remove_from_whitelist(env: &Env, address: &Address) {
+    env.storage()
+        .persistent()
+        .remove(&RateLimitKey::Whitelist(address.clone()));
+
+    env.events().publish(
+        (Symbol::new(env, "AddressRemovedFromWhitelist"),),
+        address.clone(),
+    );
+}
+
+/// Returns whether an address is whitelisted.
+pub fn is_whitelisted(env: &Env, address: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&RateLimitKey::Whitelist(address.clone()))
+        .unwrap_or(false)
+}
+
+/// Returns the current session count for an address in the active window.
+pub fn get_user_session_count(env: &Env, address: &Address) -> u32 {
+    let config = get_config(env);
+    let current_ledger = env.ledger().sequence();
+    let win_id = current_window_id(current_ledger, config.window_ledgers);
+
+    let data: Option<UserWindowData> = env
+        .storage()
+        .persistent()
+        .get(&RateLimitKey::UserWindow(address.clone()));
+
+    match data {
+        Some(d) if d.window_id == win_id => d.count,
+        _ => 0,
+    }
+}
+
+/// Check and increment the rate limit counter for `address`.
+///
+/// - If the address is whitelisted, this is a no-op.
+/// - If the address has exceeded the limit, emits a `RateLimitHit` event and
+///   panics, preventing the session from being created.
+/// - Otherwise, increments the counter and persists it.
+///
+/// Call this inside `lock_funds` (and `lock_funds_with_milestones`) BEFORE
+/// performing any token transfer.
+pub fn check_and_increment(env: &Env, address: &Address) {
+    // Whitelisted addresses have no rate limit
+    if is_whitelisted(env, address) {
+        return;
+    }
+
+    let config = get_config(env);
+    let current_ledger = env.ledger().sequence();
+    let win_id = current_window_id(current_ledger, config.window_ledgers);
+
+    let current_data: Option<UserWindowData> = env
+        .storage()
+        .persistent()
+        .get(&RateLimitKey::UserWindow(address.clone()));
+
+    let count = match current_data {
+        // Same window — use existing count
+        Some(d) if d.window_id == win_id => d.count,
+        // Different window (or none) — counter resets to 0
+        _ => 0,
+    };
+
+    if count >= config.max_sessions {
+        // Emit monitoring event before panicking
+        env.events().publish(
+            (Symbol::new(env, "RateLimitHit"), address.clone()),
+            (count, config.max_sessions, win_id),
+        );
+        panic!(
+            "RateLimitExceeded: address has reached {} sessions in this window",
+            config.max_sessions
+        );
+    }
+
+    // Increment and persist
+    env.storage().persistent().set(
+        &RateLimitKey::UserWindow(address.clone()),
+        &UserWindowData {
+            window_id: win_id,
+            count: count + 1,
+        },
+    );
+}
+
+/// Returns the current rate limit configuration.
+pub fn get_rate_limit_config(env: &Env) -> RateLimitConfig {
+    get_config(env)
+}

--- a/contracts/escrow/src/reentrancy.rs
+++ b/contracts/escrow/src/reentrancy.rs
@@ -1,0 +1,74 @@
+// ============================================================================
+// reentrancy.rs — Issue: Non-Reentrant Guard (Error code 700)
+//
+// Soroban contracts are single-threaded and cross-contract calls are
+// synchronous, so reentrancy CAN occur when this contract calls an external
+// token contract that itself calls back into this contract.
+//
+// Pattern:
+//   1. Set LOCK flag in instance storage BEFORE the external call.
+//   2. Clear the flag AFTER the external call returns.
+//   3. Any entry-point that finds the flag already set panics with code 700.
+// ============================================================================
+
+use soroban_sdk::{symbol_short, Env, Symbol};
+
+/// Instance-storage key for the reentrancy lock.
+const REENTRANT_KEY: Symbol = symbol_short!("RE_LOCK");
+
+/// Error code emitted when a reentrant call is detected.
+pub const REENTRANCY_ERROR_CODE: u32 = 700;
+
+/// Acquire the reentrancy lock.
+///
+/// Panics with `ReentrancyDetected (700)` if the lock is already held,
+/// indicating a reentrant call is in progress.
+///
+/// # Usage
+/// ```rust
+/// reentrancy::acquire(&env);
+/// // ... perform token transfer ...
+/// reentrancy::release(&env);
+/// ```
+pub fn acquire(env: &Env) {
+    let locked: bool = env
+        .storage()
+        .instance()
+        .get(&REENTRANT_KEY)
+        .unwrap_or(false);
+
+    if locked {
+        // Error code 700 — ReentrancyDetected
+        panic!("ReentrancyDetected: error code 700");
+    }
+
+    env.storage().instance().set(&REENTRANT_KEY, &true);
+}
+
+/// Release the reentrancy lock.
+///
+/// Must be called after every successful `acquire`. Failing to call this
+/// will permanently lock the contract instance (storage is persistent across
+/// ledgers for instance storage within a single invocation, but resets across
+/// separate top-level invocations — however it is best practice to always
+/// release explicitly).
+pub fn release(env: &Env) {
+    env.storage().instance().set(&REENTRANT_KEY, &false);
+}
+
+/// Convenience guard: acquires lock, runs `f`, then releases — even if `f`
+/// panics (Soroban unwinds storage changes on panic, so the lock is
+/// effectively released by the revert, but we release explicitly for clarity).
+///
+/// Example:
+/// ```rust
+/// reentrancy::guarded(&env, || {
+///     token::Client::new(&env, &token_id)
+///         .transfer(&env.current_contract_address(), &recipient, &amount);
+/// });
+/// ```
+pub fn guarded<F: FnOnce()>(env: &Env, f: F) {
+    acquire(env);
+    f();
+    release(env);
+}


### PR DESCRIPTION
## feat(contract): reentrancy guard, milestone escrow, rate limiting & session expiry

Addresses four security and flexibility issues across the SkillSync escrow contract.

**Reentrancy Guard**
Introduces a `non_reentrant` flag in instance storage that is set before and cleared after every token transfer. Any reentrant call reverts with error code 700 (`ReentrancyDetected`). Applied to `approve_session`, `refund_session`, `resolve_dispute`, and `auto_refund`.

**Milestone-Based Escrow**
Adds `lock_funds_with_milestones` and `release_milestone` to support staged payouts (e.g. 30/40/30 BPS splits). Milestone percentages must sum to exactly 10,000 BPS. Disputes pause releases; admin can resolve with a configurable buyer/seller split. Emits `MilestoneReleased` on each payout.

**Rate Limiting**
Prevents spam and DoS via a rolling ledger window. Admin configures `max_sessions` and `window_ledgers`; buyers exceeding the limit are blocked and a `RateLimitHit` event is emitted for monitoring. Specific addresses can be whitelisted to bypass limits.

**Session Expiry**
Locked sessions now record an `expires_at` ledger on creation (default 30,000 ledgers ≈ 7 days). Anyone can call `cancel_expired_session` after expiry to refund the buyer in full with no fee. State-advancing functions (`complete_session`, `approve_session`) are blocked post-expiry. Emits `SessionExpiredAndCancelled`.

**New files:** `reentrancy.rs`, `milestone.rs`, `rate_limit.rs`, `expiry.rs`
**Modified:** `lib.rs`, `test.rs`


Closes #576
Closes #577
Closes #578
Closes #579