### PR TITLE
Feat/nonce

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthController } from './auth.controller';
 import typeormConfig from './config/typeorm.config';
 
 import { RedisModule } from './redis/redis.module';
@@ -17,7 +18,7 @@ import cacheConfig from './config/cache.config';
     CacheModule.register(cacheConfig),
     RedisModule,
   ],
-  controllers: [AppController],
+  controllers: [AppController, AuthController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/auth.controller.spec.ts
+++ b/backend/src/auth.controller.spec.ts
@@ -1,0 +1,54 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { RedisService } from './redis/redis.service';
+
+const validStellarAddress = 'GCFX3YN77M5QMZJGZW3GNMXLI3NQ6O5O7PMKFYSJ7RVMDG4OPDUM5A7R';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let redisService: RedisService;
+  let mockClient: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    mockClient = {
+      incr: jest.fn(),
+      expire: jest.fn(),
+    };
+
+    redisService = {
+      set: jest.fn(),
+      getClient: jest.fn().mockReturnValue(mockClient),
+    } as unknown as RedisService;
+
+    controller = new AuthController(redisService);
+  });
+
+  it('returns a nonce and expiresAt for a valid Stellar wallet address', async () => {
+    mockClient.incr.mockResolvedValue(1);
+
+    const result = await controller.getNonce(validStellarAddress);
+
+    expect(typeof result.nonce).toBe('string');
+    expect(result.nonce).toHaveLength(64);
+    expect(result.nonce).toMatch(/^[0-9a-f]+$/);
+    expect(new Date(result.expiresAt).getTime()).toBeGreaterThan(Date.now());
+    expect(redisService.set).toHaveBeenCalledWith(validStellarAddress, result.nonce, 300, 'nonce');
+    expect(mockClient.expire).toHaveBeenCalledWith(`rate:${validStellarAddress}`, 60);
+  });
+
+  it('throws BAD_REQUEST for an invalid Stellar wallet address', async () => {
+    await expect(controller.getNonce('invalid-address')).rejects.toThrow(HttpException);
+    await expect(controller.getNonce('invalid-address')).rejects.toMatchObject({
+      status: HttpStatus.BAD_REQUEST,
+    });
+  });
+
+  it('throws TOO_MANY_REQUESTS when rate limit is exceeded', async () => {
+    mockClient.incr.mockResolvedValue(6);
+
+    await expect(controller.getNonce(validStellarAddress)).rejects.toThrow(HttpException);
+    await expect(controller.getNonce(validStellarAddress)).rejects.toMatchObject({
+      status: HttpStatus.TOO_MANY_REQUESTS,
+    });
+  });
+});

--- a/backend/src/auth.controller.ts
+++ b/backend/src/auth.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, HttpException, HttpStatus, Param } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { RedisService } from './redis/redis.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly redisService: RedisService) {}
+
+  @Get('nonce/:walletAddress')
+  async getNonce(@Param('walletAddress') walletAddress: string) {
+    if (!this.isValidStellarAddress(walletAddress)) {
+      throw new HttpException('Invalid Stellar wallet address', HttpStatus.BAD_REQUEST);
+    }
+
+    await this.enforceRateLimit(walletAddress);
+
+    const nonce = randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+
+    await this.redisService.set(walletAddress, nonce, 300, 'nonce');
+
+    return { nonce, expiresAt };
+  }
+
+  private isValidStellarAddress(address: string): boolean {
+    return /^G[A-Z2-7]{55}$/.test(address);
+  }
+
+  private async enforceRateLimit(walletAddress: string): Promise<void> {
+    const rateKey = `rate:${walletAddress}`;
+    const client = this.redisService.getClient();
+    const currentCount = await client.incr(rateKey);
+
+    if (currentCount === 1) {
+      await client.expire(rateKey, 60);
+    }
+
+    if (currentCount > 5) {
+      throw new HttpException('Rate limit exceeded', HttpStatus.TOO_MANY_REQUESTS);
+    }
+  }
+}


### PR DESCRIPTION
## ✅ Implementation Complete

Added support for `GET /auth/nonce/:walletAddress` with:

- Cryptographically secure nonce: `crypto.randomBytes(32)` serialized as hex
- Redis storage under `nonce:{walletAddress}` with 5-minute TTL
- Stellar wallet address validation
- Per-wallet rate limiting: 5 requests/minute
- Previous nonce replaced on each new request
- Returns:
  - `{ nonce: string, expiresAt: ISOString }`

## Files changed

- auth.controller.ts
- app.module.ts
- auth.controller.spec.ts

## Notes

- `npm test` was not executed because the terminal message indicated the user skipped tool invocation.
- Type checking reports no syntax errors in the new files.

Made changes.


Closes #688 