### PR TITLE
Feat/jwt

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,11 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^1.0.0",
-    "uuid": "^14.0.1"
+    "uuid": "^14.0.1",
+    "@nestjs/jwt": "^11.0.0",
+    "@nestjs/passport": "^11.0.0",
+    "passport": "^0.6.0",
+    "passport-jwt": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -25,4 +25,10 @@ export class AppController {
       return { status: 'error', message: e.message };
     }
   }
+
+  @Get('protected')
+  @UseGuards(JwtAuthGuard)
+  getProtected(@Req() req: Request) {
+    return { status: 'ok', user: req.user };
+  }
 }

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Request } from 'express';
 import { AppService } from './app.service';
 import { RedisService } from './redis/redis.service';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @Controller()
 export class AppController {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,10 +3,10 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { AuthController } from './auth.controller';
 import typeormConfig from './config/typeorm.config';
 
 import { RedisModule } from './redis/redis.module';
+import { AuthModule } from './auth.module';
 
 import { CacheModule } from '@nestjs/cache-manager';
 import cacheConfig from './config/cache.config';
@@ -17,8 +17,9 @@ import cacheConfig from './config/cache.config';
     TypeOrmModule.forRoot(typeormConfig),
     CacheModule.register(cacheConfig),
     RedisModule,
+    AuthModule,
   ],
-  controllers: [AppController, AuthController],
+  controllers: [AppController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthController } from './auth.controller';
 import typeormConfig from './config/typeorm.config';
 
 import { RedisModule } from './redis/redis.module';
@@ -17,7 +18,7 @@ import cacheConfig from './config/cache.config';
     CacheModule.register(cacheConfig),
     RedisModule,
   ],
-  controllers: [AppController],
+  controllers: [AppController, AuthController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/auth.controller.spec.ts
+++ b/backend/src/auth.controller.spec.ts
@@ -1,0 +1,54 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { RedisService } from './redis/redis.service';
+
+const validStellarAddress = 'GCFX3YN77M5QMZJGZW3GNMXLI3NQ6O5O7PMKFYSJ7RVMDG4OPDUM5A7R';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let redisService: RedisService;
+  let mockClient: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    mockClient = {
+      incr: jest.fn(),
+      expire: jest.fn(),
+    };
+
+    redisService = {
+      set: jest.fn(),
+      getClient: jest.fn().mockReturnValue(mockClient),
+    } as unknown as RedisService;
+
+    controller = new AuthController(redisService);
+  });
+
+  it('returns a nonce and expiresAt for a valid Stellar wallet address', async () => {
+    mockClient.incr.mockResolvedValue(1);
+
+    const result = await controller.getNonce(validStellarAddress);
+
+    expect(typeof result.nonce).toBe('string');
+    expect(result.nonce).toHaveLength(64);
+    expect(result.nonce).toMatch(/^[0-9a-f]+$/);
+    expect(new Date(result.expiresAt).getTime()).toBeGreaterThan(Date.now());
+    expect(redisService.set).toHaveBeenCalledWith(validStellarAddress, result.nonce, 300, 'nonce');
+    expect(mockClient.expire).toHaveBeenCalledWith(`rate:${validStellarAddress}`, 60);
+  });
+
+  it('throws BAD_REQUEST for an invalid Stellar wallet address', async () => {
+    await expect(controller.getNonce('invalid-address')).rejects.toThrow(HttpException);
+    await expect(controller.getNonce('invalid-address')).rejects.toMatchObject({
+      status: HttpStatus.BAD_REQUEST,
+    });
+  });
+
+  it('throws TOO_MANY_REQUESTS when rate limit is exceeded', async () => {
+    mockClient.incr.mockResolvedValue(6);
+
+    await expect(controller.getNonce(validStellarAddress)).rejects.toThrow(HttpException);
+    await expect(controller.getNonce(validStellarAddress)).rejects.toMatchObject({
+      status: HttpStatus.TOO_MANY_REQUESTS,
+    });
+  });
+});

--- a/backend/src/auth.controller.ts
+++ b/backend/src/auth.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, HttpException, HttpStatus, Param } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { RedisService } from './redis/redis.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly redisService: RedisService) {}
+
+  @Get('nonce/:walletAddress')
+  async getNonce(@Param('walletAddress') walletAddress: string) {
+    if (!this.isValidStellarAddress(walletAddress)) {
+      throw new HttpException('Invalid Stellar wallet address', HttpStatus.BAD_REQUEST);
+    }
+
+    await this.enforceRateLimit(walletAddress);
+
+    const nonce = randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+
+    await this.redisService.set(walletAddress, nonce, 300, 'nonce');
+
+    return { nonce, expiresAt };
+  }
+
+  private isValidStellarAddress(address: string): boolean {
+    return /^G[A-Z2-7]{55}$/.test(address);
+  }
+
+  private async enforceRateLimit(walletAddress: string): Promise<void> {
+    const rateKey = `rate:${walletAddress}`;
+    const client = this.redisService.getClient();
+    const currentCount = await client.incr(rateKey);
+
+    if (currentCount === 1) {
+      await client.expire(rateKey, 60);
+    }
+
+    if (currentCount > 5) {
+      throw new HttpException('Rate limit exceeded', HttpStatus.TOO_MANY_REQUESTS);
+    }
+  }
+}

--- a/backend/src/auth.controller.ts
+++ b/backend/src/auth.controller.ts
@@ -1,10 +1,21 @@
-import { Controller, Get, HttpException, HttpStatus, Param } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, HttpStatus, Param, Post } from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { RedisService } from './redis/redis.service';
+import { AuthService } from './auth.service';
+
+interface IssueTokenDto {
+  userId: string;
+  wallet: string;
+  roles: string[];
+  permissions: string[];
+}
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly redisService: RedisService) {}
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly authService: AuthService,
+  ) {}
 
   @Get('nonce/:walletAddress')
   async getNonce(@Param('walletAddress') walletAddress: string) {
@@ -20,6 +31,22 @@ export class AuthController {
     await this.redisService.set(walletAddress, nonce, 300, 'nonce');
 
     return { nonce, expiresAt };
+  }
+
+  @Post('token')
+  async issueToken(@Body() body: IssueTokenDto) {
+    if (!body.userId || !body.wallet || !Array.isArray(body.roles) || !Array.isArray(body.permissions)) {
+      throw new HttpException('Missing token payload fields', HttpStatus.BAD_REQUEST);
+    }
+
+    return {
+      accessToken: await this.authService.issueAccessToken(
+        body.userId,
+        body.wallet,
+        body.roles,
+        body.permissions,
+      ),
+    };
   }
 
   private isValidStellarAddress(address: string): boolean {

--- a/backend/src/auth.module.ts
+++ b/backend/src/auth.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -8,6 +9,7 @@ import { RedisModule } from './redis/redis.module';
 
 @Module({
   imports: [
+    PassportModule.register({ defaultStrategy: 'jwt' }),
     RedisModule,
     JwtModule.registerAsync({
       inject: [ConfigService],

--- a/backend/src/auth.module.ts
+++ b/backend/src/auth.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './jwt.strategy';
+import { RedisModule } from './redis/redis.module';
+
+@Module({
+  imports: [
+    RedisModule,
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => {
+        const algorithm = config.get('JWT_ALGORITHM') || (config.get('JWT_PRIVATE_KEY') ? 'RS256' : 'HS256');
+        const secretOrKey = algorithm === 'RS256' ? config.get<string>('JWT_PUBLIC_KEY') : config.get<string>('JWT_SECRET');
+        if (!secretOrKey) {
+          throw new Error('JWT_SECRET or JWT_PUBLIC_KEY must be configured');
+        }
+
+        return {
+          secret: secretOrKey,
+          signOptions: {
+            algorithm,
+            expiresIn: config.get('JWT_ACCESS_EXPIRATION', '15m'),
+            issuer: config.get('JWT_ISSUER', 'SkillSync'),
+            audience: config.get('JWT_AUDIENCE', 'SkillSync'),
+          },
+        };
+      },
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth.service.ts
+++ b/backend/src/auth.service.ts
@@ -47,11 +47,27 @@ export class AuthService {
 
   async incrementTokenVersion(userId: string): Promise<number> {
     const client = this.redisService.getClient();
-    return client.incr(`tokenVersion:${userId}`);
+    const version = await client.incr(`tokenVersion:${userId}`);
+    await client.set(`tokenVersionUpdatedAt:${userId}`, Math.floor(Date.now() / 1000).toString());
+    return version;
+  }
+
+  async getTokenVersionUpdatedAt(userId: string): Promise<number> {
+    const timestamp = await this.redisService.get(`tokenVersionUpdatedAt:${userId}`);
+    return timestamp ? Number(timestamp) : 0;
   }
 
   async validateTokenVersion(payload: JwtAccessTokenPayload): Promise<boolean> {
     const currentVersion = await this.getTokenVersion(payload.sub);
-    return payload.ver === currentVersion;
+    if (payload.ver !== currentVersion) {
+      return false;
+    }
+
+    const versionUpdatedAt = await this.getTokenVersionUpdatedAt(payload.sub);
+    if (versionUpdatedAt && payload.iat && payload.iat < versionUpdatedAt) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/backend/src/auth.service.ts
+++ b/backend/src/auth.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { v4 as uuidv4 } from 'uuid';
+import { RedisService } from './redis/redis.service';
+import { JwtAccessTokenPayload } from './jwt-payload.interface';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async issueAccessToken(userId: string, wallet: string, roles: string[], permissions: string[]): Promise<string> {
+    const version = await this.getTokenVersion(userId);
+    const jti = uuidv4();
+    const payload: JwtAccessTokenPayload = {
+      sub: userId,
+      wallet,
+      roles,
+      permissions,
+      jti,
+      ver: version,
+    };
+
+    const algorithm = this.configService.get<string>('JWT_ALGORITHM') || (this.configService.get('JWT_PRIVATE_KEY') ? 'RS256' : 'HS256');
+    const signOptions: Record<string, unknown> = { jwtid: jti };
+
+    if (algorithm === 'RS256') {
+      const privateKey = this.configService.get<string>('JWT_PRIVATE_KEY');
+      if (!privateKey) {
+        throw new Error('JWT_PRIVATE_KEY must be configured for RS256 signing');
+      }
+      signOptions.privateKey = privateKey;
+      signOptions.algorithm = 'RS256';
+    }
+
+    return this.jwtService.signAsync(payload, signOptions);
+  }
+
+  async getTokenVersion(userId: string): Promise<number> {
+    const version = await this.redisService.get(userId, 'tokenVersion');
+    return version ? Number(version) : 0;
+  }
+
+  async incrementTokenVersion(userId: string): Promise<number> {
+    const client = this.redisService.getClient();
+    return client.incr(`tokenVersion:${userId}`);
+  }
+
+  async validateTokenVersion(payload: JwtAccessTokenPayload): Promise<boolean> {
+    const currentVersion = await this.getTokenVersion(payload.sub);
+    return payload.ver === currentVersion;
+  }
+}

--- a/backend/src/jwt-auth.guard.ts
+++ b/backend/src/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend/src/jwt-payload.interface.ts
+++ b/backend/src/jwt-payload.interface.ts
@@ -1,0 +1,12 @@
+export interface JwtAccessTokenPayload {
+  sub: string;
+  wallet: string;
+  roles: string[];
+  permissions: string[];
+  jti: string;
+  ver: number;
+  iss?: string;
+  aud?: string;
+  iat?: number;
+  exp?: number;
+}

--- a/backend/src/jwt.strategy.ts
+++ b/backend/src/jwt.strategy.ts
@@ -1,0 +1,49 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { AuthService } from './auth.service';
+import { JwtAccessTokenPayload } from './jwt-payload.interface';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(private readonly configService: ConfigService, private readonly authService: AuthService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: JwtStrategy.createSecret(configService),
+      algorithms: [configService.get('JWT_ALGORITHM') || 'HS256'],
+    });
+  }
+
+  private static createSecret(configService: ConfigService): string {
+    const algorithm = configService.get('JWT_ALGORITHM') || (configService.get('JWT_PRIVATE_KEY') ? 'RS256' : 'HS256');
+    if (algorithm === 'RS256') {
+      const publicKey = configService.get<string>('JWT_PUBLIC_KEY');
+      if (!publicKey) {
+        throw new Error('JWT_PUBLIC_KEY is required for RS256 verification');
+      }
+      return publicKey;
+    }
+
+    const secret = configService.get<string>('JWT_SECRET');
+    if (!secret) {
+      throw new Error('JWT_SECRET is required for HS256 verification');
+    }
+
+    return secret;
+  }
+
+  async validate(payload: JwtAccessTokenPayload): Promise<JwtAccessTokenPayload> {
+    if (!payload.sub || !payload.wallet || !payload.jti) {
+      throw new UnauthorizedException('Invalid token payload');
+    }
+
+    const validVersion = await this.authService.validateTokenVersion(payload);
+    if (!validVersion) {
+      throw new UnauthorizedException('Token version invalidated');
+    }
+
+    return payload;
+  }
+}


### PR DESCRIPTION
All intended changes are now in place.

## What was implemented

- `AuthModule` added
- JWT issuance via `AuthService.issueAccessToken(...)`
- Payload contains: `sub`, `wallet`, `roles`, `permissions`, `jti`, `ver`
- JWT signing supports `HS256` and `RS256` driven by env vars
- Configurable expiration via `JWT_ACCESS_EXPIRATION` (defaults to `15m`)
- `JwtStrategy` verifies token signature and version
- `JwtAuthGuard` protects endpoints
- `AuthController` exposes `POST /auth/token`
- `AppController` exposes `GET /protected` for JWT-guarded access

## Notes

- package.json now includes required JWT/Passport dependencies
- Token invalidation uses Redis `tokenVersion` and `tokenVersionUpdatedAt`
- `AppModule` imports `AuthModule`

If you want, I can now add unit tests for the JWT service and guard.

Made changes.

Closes #690 