### PR TITLE
Feat/filter

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,11 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^1.0.0",
-    "uuid": "^14.0.1"
+    "uuid": "^14.0.1",
+    "@nestjs/jwt": "^11.0.0",
+    "@nestjs/passport": "^11.0.0",
+    "passport": "^0.6.0",
+    "passport-jwt": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -25,4 +25,10 @@ export class AppController {
       return { status: 'error', message: e.message };
     }
   }
+
+  @Get('protected')
+  @UseGuards(JwtAuthGuard)
+  getProtected(@Req() req: Request) {
+    return { status: 'ok', user: req.user };
+  }
 }

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Request } from 'express';
 import { AppService } from './app.service';
 import { RedisService } from './redis/redis.service';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @Controller()
 export class AppController {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,10 +3,10 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { AuthController } from './auth.controller';
 import typeormConfig from './config/typeorm.config';
 
 import { RedisModule } from './redis/redis.module';
+import { AuthModule } from './auth.module';
 
 import { CacheModule } from '@nestjs/cache-manager';
 import cacheConfig from './config/cache.config';
@@ -17,8 +17,9 @@ import cacheConfig from './config/cache.config';
     TypeOrmModule.forRoot(typeormConfig),
     CacheModule.register(cacheConfig),
     RedisModule,
+    AuthModule,
   ],
-  controllers: [AppController, AuthController],
+  controllers: [AppController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthController } from './auth.controller';
 import typeormConfig from './config/typeorm.config';
 
 import { RedisModule } from './redis/redis.module';
@@ -17,7 +18,7 @@ import cacheConfig from './config/cache.config';
     CacheModule.register(cacheConfig),
     RedisModule,
   ],
-  controllers: [AppController],
+  controllers: [AppController, AuthController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/auth.controller.spec.ts
+++ b/backend/src/auth.controller.spec.ts
@@ -1,0 +1,54 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { RedisService } from './redis/redis.service';
+
+const validStellarAddress = 'GCFX3YN77M5QMZJGZW3GNMXLI3NQ6O5O7PMKFYSJ7RVMDG4OPDUM5A7R';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let redisService: RedisService;
+  let mockClient: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    mockClient = {
+      incr: jest.fn(),
+      expire: jest.fn(),
+    };
+
+    redisService = {
+      set: jest.fn(),
+      getClient: jest.fn().mockReturnValue(mockClient),
+    } as unknown as RedisService;
+
+    controller = new AuthController(redisService);
+  });
+
+  it('returns a nonce and expiresAt for a valid Stellar wallet address', async () => {
+    mockClient.incr.mockResolvedValue(1);
+
+    const result = await controller.getNonce(validStellarAddress);
+
+    expect(typeof result.nonce).toBe('string');
+    expect(result.nonce).toHaveLength(64);
+    expect(result.nonce).toMatch(/^[0-9a-f]+$/);
+    expect(new Date(result.expiresAt).getTime()).toBeGreaterThan(Date.now());
+    expect(redisService.set).toHaveBeenCalledWith(validStellarAddress, result.nonce, 300, 'nonce');
+    expect(mockClient.expire).toHaveBeenCalledWith(`rate:${validStellarAddress}`, 60);
+  });
+
+  it('throws BAD_REQUEST for an invalid Stellar wallet address', async () => {
+    await expect(controller.getNonce('invalid-address')).rejects.toThrow(HttpException);
+    await expect(controller.getNonce('invalid-address')).rejects.toMatchObject({
+      status: HttpStatus.BAD_REQUEST,
+    });
+  });
+
+  it('throws TOO_MANY_REQUESTS when rate limit is exceeded', async () => {
+    mockClient.incr.mockResolvedValue(6);
+
+    await expect(controller.getNonce(validStellarAddress)).rejects.toThrow(HttpException);
+    await expect(controller.getNonce(validStellarAddress)).rejects.toMatchObject({
+      status: HttpStatus.TOO_MANY_REQUESTS,
+    });
+  });
+});

--- a/backend/src/auth.controller.ts
+++ b/backend/src/auth.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, HttpException, HttpStatus, Param } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { RedisService } from './redis/redis.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly redisService: RedisService) {}
+
+  @Get('nonce/:walletAddress')
+  async getNonce(@Param('walletAddress') walletAddress: string) {
+    if (!this.isValidStellarAddress(walletAddress)) {
+      throw new HttpException('Invalid Stellar wallet address', HttpStatus.BAD_REQUEST);
+    }
+
+    await this.enforceRateLimit(walletAddress);
+
+    const nonce = randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+
+    await this.redisService.set(walletAddress, nonce, 300, 'nonce');
+
+    return { nonce, expiresAt };
+  }
+
+  private isValidStellarAddress(address: string): boolean {
+    return /^G[A-Z2-7]{55}$/.test(address);
+  }
+
+  private async enforceRateLimit(walletAddress: string): Promise<void> {
+    const rateKey = `rate:${walletAddress}`;
+    const client = this.redisService.getClient();
+    const currentCount = await client.incr(rateKey);
+
+    if (currentCount === 1) {
+      await client.expire(rateKey, 60);
+    }
+
+    if (currentCount > 5) {
+      throw new HttpException('Rate limit exceeded', HttpStatus.TOO_MANY_REQUESTS);
+    }
+  }
+}

--- a/backend/src/auth.controller.ts
+++ b/backend/src/auth.controller.ts
@@ -1,10 +1,21 @@
-import { Controller, Get, HttpException, HttpStatus, Param } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, HttpStatus, Param, Post } from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { RedisService } from './redis/redis.service';
+import { AuthService } from './auth.service';
+
+interface IssueTokenDto {
+  userId: string;
+  wallet: string;
+  roles: string[];
+  permissions: string[];
+}
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly redisService: RedisService) {}
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly authService: AuthService,
+  ) {}
 
   @Get('nonce/:walletAddress')
   async getNonce(@Param('walletAddress') walletAddress: string) {
@@ -20,6 +31,22 @@ export class AuthController {
     await this.redisService.set(walletAddress, nonce, 300, 'nonce');
 
     return { nonce, expiresAt };
+  }
+
+  @Post('token')
+  async issueToken(@Body() body: IssueTokenDto) {
+    if (!body.userId || !body.wallet || !Array.isArray(body.roles) || !Array.isArray(body.permissions)) {
+      throw new HttpException('Missing token payload fields', HttpStatus.BAD_REQUEST);
+    }
+
+    return {
+      accessToken: await this.authService.issueAccessToken(
+        body.userId,
+        body.wallet,
+        body.roles,
+        body.permissions,
+      ),
+    };
   }
 
   private isValidStellarAddress(address: string): boolean {

--- a/backend/src/auth.module.ts
+++ b/backend/src/auth.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -8,6 +9,7 @@ import { RedisModule } from './redis/redis.module';
 
 @Module({
   imports: [
+    PassportModule.register({ defaultStrategy: 'jwt' }),
     RedisModule,
     JwtModule.registerAsync({
       inject: [ConfigService],

--- a/backend/src/auth.module.ts
+++ b/backend/src/auth.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './jwt.strategy';
+import { RedisModule } from './redis/redis.module';
+
+@Module({
+  imports: [
+    RedisModule,
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => {
+        const algorithm = config.get('JWT_ALGORITHM') || (config.get('JWT_PRIVATE_KEY') ? 'RS256' : 'HS256');
+        const secretOrKey = algorithm === 'RS256' ? config.get<string>('JWT_PUBLIC_KEY') : config.get<string>('JWT_SECRET');
+        if (!secretOrKey) {
+          throw new Error('JWT_SECRET or JWT_PUBLIC_KEY must be configured');
+        }
+
+        return {
+          secret: secretOrKey,
+          signOptions: {
+            algorithm,
+            expiresIn: config.get('JWT_ACCESS_EXPIRATION', '15m'),
+            issuer: config.get('JWT_ISSUER', 'SkillSync'),
+            audience: config.get('JWT_AUDIENCE', 'SkillSync'),
+          },
+        };
+      },
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth.service.ts
+++ b/backend/src/auth.service.ts
@@ -47,11 +47,27 @@ export class AuthService {
 
   async incrementTokenVersion(userId: string): Promise<number> {
     const client = this.redisService.getClient();
-    return client.incr(`tokenVersion:${userId}`);
+    const version = await client.incr(`tokenVersion:${userId}`);
+    await client.set(`tokenVersionUpdatedAt:${userId}`, Math.floor(Date.now() / 1000).toString());
+    return version;
+  }
+
+  async getTokenVersionUpdatedAt(userId: string): Promise<number> {
+    const timestamp = await this.redisService.get(`tokenVersionUpdatedAt:${userId}`);
+    return timestamp ? Number(timestamp) : 0;
   }
 
   async validateTokenVersion(payload: JwtAccessTokenPayload): Promise<boolean> {
     const currentVersion = await this.getTokenVersion(payload.sub);
-    return payload.ver === currentVersion;
+    if (payload.ver !== currentVersion) {
+      return false;
+    }
+
+    const versionUpdatedAt = await this.getTokenVersionUpdatedAt(payload.sub);
+    if (versionUpdatedAt && payload.iat && payload.iat < versionUpdatedAt) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/backend/src/auth.service.ts
+++ b/backend/src/auth.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { v4 as uuidv4 } from 'uuid';
+import { RedisService } from './redis/redis.service';
+import { JwtAccessTokenPayload } from './jwt-payload.interface';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async issueAccessToken(userId: string, wallet: string, roles: string[], permissions: string[]): Promise<string> {
+    const version = await this.getTokenVersion(userId);
+    const jti = uuidv4();
+    const payload: JwtAccessTokenPayload = {
+      sub: userId,
+      wallet,
+      roles,
+      permissions,
+      jti,
+      ver: version,
+    };
+
+    const algorithm = this.configService.get<string>('JWT_ALGORITHM') || (this.configService.get('JWT_PRIVATE_KEY') ? 'RS256' : 'HS256');
+    const signOptions: Record<string, unknown> = { jwtid: jti };
+
+    if (algorithm === 'RS256') {
+      const privateKey = this.configService.get<string>('JWT_PRIVATE_KEY');
+      if (!privateKey) {
+        throw new Error('JWT_PRIVATE_KEY must be configured for RS256 signing');
+      }
+      signOptions.privateKey = privateKey;
+      signOptions.algorithm = 'RS256';
+    }
+
+    return this.jwtService.signAsync(payload, signOptions);
+  }
+
+  async getTokenVersion(userId: string): Promise<number> {
+    const version = await this.redisService.get(userId, 'tokenVersion');
+    return version ? Number(version) : 0;
+  }
+
+  async incrementTokenVersion(userId: string): Promise<number> {
+    const client = this.redisService.getClient();
+    return client.incr(`tokenVersion:${userId}`);
+  }
+
+  async validateTokenVersion(payload: JwtAccessTokenPayload): Promise<boolean> {
+    const currentVersion = await this.getTokenVersion(payload.sub);
+    return payload.ver === currentVersion;
+  }
+}

--- a/backend/src/exceptions/api.exception.ts
+++ b/backend/src/exceptions/api.exception.ts
@@ -1,0 +1,37 @@
+import { BadRequestException, HttpException, HttpStatus, NotFoundException, UnauthorizedException } from '@nestjs/common';
+
+export class ApiException extends HttpException {
+  constructor(response: string | Record<string, any>, status: HttpStatus) {
+    super(response, status);
+  }
+}
+
+export class ApiBadRequestException extends BadRequestException {
+  constructor(message: string | Record<string, any>) {
+    super({
+      message,
+      error: 'Bad Request',
+      errorCode: 'bad_request',
+    });
+  }
+}
+
+export class ApiNotFoundException extends NotFoundException {
+  constructor(message = 'Resource not found') {
+    super({
+      message,
+      error: 'Not Found',
+      errorCode: 'not_found',
+    });
+  }
+}
+
+export class ApiUnauthorizedException extends UnauthorizedException {
+  constructor(message = 'Unauthorized') {
+    super({
+      message,
+      error: 'Unauthorized',
+      errorCode: 'unauthorized',
+    });
+  }
+}

--- a/backend/src/exceptions/http-exception.filter.ts
+++ b/backend/src/exceptions/http-exception.filter.ts
@@ -1,0 +1,144 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { Response, Request } from 'express';
+import { ValidationError } from 'class-validator';
+
+interface FieldError {
+  field: string;
+  errors: string[];
+}
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const status = this.getStatus(exception);
+    const errorResponse = this.mapException(exception, request, status);
+
+    if (status >= 500) {
+      this.logger.error(JSON.stringify({
+        requestId: request.headers['x-request-id'] || null,
+        status,
+        path: request.url,
+        message: errorResponse.message,
+        stack: exception instanceof Error ? exception.stack : null,
+      }));
+    }
+
+    response.status(status).json(errorResponse);
+  }
+
+  private getStatus(exception: unknown): number {
+    if (exception instanceof HttpException) {
+      return exception.getStatus();
+    }
+
+    return HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+
+  private mapException(exception: unknown, request: Request, status: number) {
+    const timestamp = new Date().toISOString();
+    const path = request.url;
+    const requestId = request.headers['x-request-id'] || null;
+    const isProd = process.env.NODE_ENV === 'production';
+
+    if (exception instanceof HttpException) {
+      const response = exception.getResponse();
+
+      if (typeof response === 'string') {
+        return {
+          statusCode: status,
+          message: response,
+          error: exception.name,
+          code: this.mapErrorCode(status),
+          timestamp,
+          path,
+          requestId,
+          ...(exception instanceof Error && !isProd ? { stack: exception.stack } : {}),
+        };
+      }
+
+      const payload = response as any;
+      const validation = this.extractValidationErrors(payload);
+
+      return {
+        statusCode: status,
+        message: payload.message || payload.error || exception.name,
+        error: payload.error || exception.name,
+        code: payload.errorCode || this.mapErrorCode(status),
+        timestamp,
+        path,
+        requestId,
+        ...(validation ? { validation } : {}),
+        ...(!isProd && exception instanceof Error ? { stack: exception.stack } : {}),
+      };
+    }
+
+    return {
+      statusCode: status,
+      message: 'Internal server error',
+      error: 'Internal Server Error',
+      code: 'internal_server_error',
+      timestamp,
+      path,
+      requestId,
+      ...(exception instanceof Error && !isProd ? { stack: exception.stack } : {}),
+    };
+  }
+
+  private mapErrorCode(status: number) {
+    switch (status) {
+      case HttpStatus.BAD_REQUEST:
+        return 'bad_request';
+      case HttpStatus.UNAUTHORIZED:
+        return 'unauthorized';
+      case HttpStatus.NOT_FOUND:
+        return 'not_found';
+      case HttpStatus.FORBIDDEN:
+        return 'forbidden';
+      case HttpStatus.TOO_MANY_REQUESTS:
+        return 'rate_limited';
+      default:
+        return 'internal_server_error';
+    }
+  }
+
+  private extractValidationErrors(payload: any): FieldError[] | null {
+    const errors = payload.message || payload?.message;
+    if (!Array.isArray(payload?.message) && !Array.isArray(errors)) {
+      return null;
+    }
+
+    const validationErrors = Array.isArray(payload.message) ? payload.message : [];
+
+    return validationErrors.reduce((result: FieldError[], error: any) => {
+      if (error.property && Array.isArray(error.constraints)) {
+        result.push({ field: error.property, errors: Object.values(error.constraints) });
+        return result;
+      }
+
+      const children = error.children;
+      if (children && children.length) {
+        const childErrors = this.flattenChildren(error.property, children);
+        return result.concat(childErrors);
+      }
+
+      return result;
+    }, []);
+  }
+
+  private flattenChildren(parent: string, children: ValidationError[]): FieldError[] {
+    return children.flatMap((child) => {
+      const field = `${parent}.${child.property}`;
+      const errors = child.constraints ? Object.values(child.constraints) : [];
+
+      return [{ field, errors }].concat(
+        child.children ? this.flattenChildren(field, child.children) : [],
+      );
+    });
+  }
+}

--- a/backend/src/exceptions/request-id.middleware.ts
+++ b/backend/src/exceptions/request-id.middleware.ts
@@ -1,0 +1,13 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class RequestIdMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const requestId = req.headers['x-request-id'] as string || uuidv4();
+    req.headers['x-request-id'] = requestId;
+    res.setHeader('x-request-id', requestId);
+    next();
+  }
+}

--- a/backend/src/jwt-auth.guard.ts
+++ b/backend/src/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend/src/jwt-payload.interface.ts
+++ b/backend/src/jwt-payload.interface.ts
@@ -1,0 +1,12 @@
+export interface JwtAccessTokenPayload {
+  sub: string;
+  wallet: string;
+  roles: string[];
+  permissions: string[];
+  jti: string;
+  ver: number;
+  iss?: string;
+  aud?: string;
+  iat?: number;
+  exp?: number;
+}

--- a/backend/src/jwt.strategy.ts
+++ b/backend/src/jwt.strategy.ts
@@ -1,0 +1,49 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { AuthService } from './auth.service';
+import { JwtAccessTokenPayload } from './jwt-payload.interface';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(private readonly configService: ConfigService, private readonly authService: AuthService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: JwtStrategy.createSecret(configService),
+      algorithms: [configService.get('JWT_ALGORITHM') || 'HS256'],
+    });
+  }
+
+  private static createSecret(configService: ConfigService): string {
+    const algorithm = configService.get('JWT_ALGORITHM') || (configService.get('JWT_PRIVATE_KEY') ? 'RS256' : 'HS256');
+    if (algorithm === 'RS256') {
+      const publicKey = configService.get<string>('JWT_PUBLIC_KEY');
+      if (!publicKey) {
+        throw new Error('JWT_PUBLIC_KEY is required for RS256 verification');
+      }
+      return publicKey;
+    }
+
+    const secret = configService.get<string>('JWT_SECRET');
+    if (!secret) {
+      throw new Error('JWT_SECRET is required for HS256 verification');
+    }
+
+    return secret;
+  }
+
+  async validate(payload: JwtAccessTokenPayload): Promise<JwtAccessTokenPayload> {
+    if (!payload.sub || !payload.wallet || !payload.jti) {
+      throw new UnauthorizedException('Invalid token payload');
+    }
+
+    const validVersion = await this.authService.validateTokenVersion(payload);
+    if (!validVersion) {
+      throw new UnauthorizedException('Token version invalidated');
+    }
+
+    return payload;
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 
 import { LoggingMiddleware } from './middleware/logging.middleware';
+import { RequestIdMiddleware } from './exceptions/request-id.middleware';
+import { HttpExceptionFilter } from './exceptions/http-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,7 +9,18 @@ import { HttpExceptionFilter } from './exceptions/http-exception.filter';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const logger = new LoggingMiddleware();
+  const requestIdMiddleware = new RequestIdMiddleware();
+
   app.use(logger.use.bind(logger));
+  app.use(requestIdMiddleware.use.bind(requestIdMiddleware));
+  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      exceptionFactory: (errors) => errors,
+    }),
+  );
   const port = process.env.PORT ?? 3000;
   await app.listen(port);
   Logger.log(`Server running on http://localhost:${port}`, 'Bootstrap');


### PR DESCRIPTION
Replacing 10 lines with 22 lines in [](file:///workspaces/SkillSync_Server/backend/src/main.ts)

Confirming exact main.ts function block to patch global filter registration precisely.

ReaThe global exception filter and request ID middleware are now registered in main.ts.

## Completed
- Added `HttpExceptionFilter` and `RequestIdMiddleware`
- Configured `ValidationPipe` globally
- Updated bootstrap to register middleware/filter

If you want, I can also add a simple e2e or unit test for the exception filter.

Made changes.

Closes #686