### PR TITLE
feat: fix request ID propagation and add response header interceptor

### DIFF
--- a/backend/src/exceptions/request-id.interceptor.ts
+++ b/backend/src/exceptions/request-id.interceptor.ts
@@ -1,0 +1,16 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Injectable()
+export class RequestIdInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
+    const requestId = req.headers['x-request-id'];
+    if (requestId) {
+      res.setHeader('X-Request-Id', requestId);
+    }
+    return next.handle();
+  }
+}

--- a/backend/src/exceptions/request-id.middleware.ts
+++ b/backend/src/exceptions/request-id.middleware.ts
@@ -8,6 +8,7 @@ export class RequestIdMiddleware implements NestMiddleware {
     const requestId = req.headers['x-request-id'] as string || uuidv4();
     req.headers['x-request-id'] = requestId;
     res.setHeader('x-request-id', requestId);
+    res.locals.requestId = requestId;
     next();
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,6 +5,7 @@ import { Logger, ValidationPipe } from '@nestjs/common';
 import { LoggingMiddleware } from './middleware/logging.middleware';
 import { RequestIdMiddleware } from './exceptions/request-id.middleware';
 import { HttpExceptionFilter } from './exceptions/http-exception.filter';
+import { RequestIdInterceptor } from './exceptions/request-id.interceptor';
 import { ShutdownService } from './shutdown/shutdown.service';
 
 const SHUTDOWN_TIMEOUT_MS = 30_000;
@@ -19,6 +20,7 @@ async function bootstrap() {
   app.use(loggingMiddleware.use.bind(loggingMiddleware));
   app.use(requestIdMiddleware.use.bind(requestIdMiddleware));
   app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalInterceptors(new RequestIdInterceptor());
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/backend/src/middleware/logging.middleware.ts
+++ b/backend/src/middleware/logging.middleware.ts
@@ -11,7 +11,7 @@ export class LoggingMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: NextFunction) {
     const { ip, method, originalUrl, body, headers } = req;
     const userAgent = req.get('user-agent') || '';
-    const requestId = uuidv4();
+    const requestId = (req.headers['x-request-id'] as string) ?? uuidv4();
 
     const start = process.hrtime();
 

--- a/pr-743.md
+++ b/pr-743.md
@@ -1,0 +1,7 @@
+## Summary
+
+- Fixed `LoggingMiddleware` to use the shared `x-request-id` from `RequestIdMiddleware` instead of generating a separate UUID, ensuring all logs for a request share one ID
+- Added `RequestIdInterceptor` to guarantee `X-Request-Id` is present on all success responses
+- `requestId` already included in error responses via `HttpExceptionFilter` (no change needed)
+
+Closes #743


### PR DESCRIPTION
## Summary

- Fixed `LoggingMiddleware` to use the shared `x-request-id` from `RequestIdMiddleware` instead of generating a separate UUID, ensuring all logs for a request share one ID
- Added `RequestIdInterceptor` to guarantee `X-Request-Id` is present on all success responses
- `requestId` already included in error responses via `HttpExceptionFilter` (no change needed)

Closes #743
