### PR TITLE
session funtion

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Bytes, Env, String,
+    contract, contractimpl, contracttype, symbol_short, token, Address, Bytes, BytesN, Env, String,
 };
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
@@ -13,12 +13,14 @@ pub enum DataKey {
     PlatformFeeBps,
     DisputeWindow,
     Initialized,
-    Session(Bytes),           // sessions mapping keyed by session_id
-    ExtensionProposal(Bytes), // Issue #801: pending extension proposal
-    Initialized,    // sessions mapping keyed by session_id
-    SessionMeta(Bytes), // Issue #794: metadata URI per session
-    Session(Bytes),      // sessions mapping keyed by session_id
-    TokenSession(Bytes), // Issue #793: token-based sessions
+    Paused,
+    TotalVolume,
+    TotalSessions,
+    ActiveSessions,
+    Session(Bytes),
+    ExtensionProposal(Bytes),
+    SessionMeta(Bytes),
+    TokenSession(Bytes),
 }
 
 // ── Issue #754: Session status enum ──────────────────────────────────────────
@@ -50,15 +52,6 @@ pub struct Session {
     pub deadline: u32, // Issue #801: completion deadline in ledgers (0 = no deadline)
 }
 
-// ── Issue #801: Extension proposal struct ────────────────────────────────────
-
-#[contracttype]
-#[derive(Clone)]
-pub struct ExtensionProposal {
-    pub proposer: Address,
-    pub additional_ledgers: u32,
-}
-
 // ── Issue #793: Token session struct ─────────────────────────────────────────
 
 #[contracttype]
@@ -70,28 +63,6 @@ pub struct TokenSession {
     pub amount: i128,
     pub status: SessionStatus,
     pub created_at: u32,
-}
-
-// ── Issue #793: TokenSession struct ──────────────────────────────────────────
-
-#[contracttype]
-#[derive(Clone)]
-pub struct TokenSession {
-    pub buyer: Address,
-    pub seller: Address,
-    pub amount: i128,
-    pub token: Address,
-    pub status: SessionStatus,
-    pub created_at: u32,
-}
-
-// ── Issue #801: ExtensionProposal struct ──────────────────────────────────────
-
-#[contracttype]
-#[derive(Clone)]
-pub struct ExtensionProposal {
-    pub proposed_by: Address,
-    pub additional_ledgers: u32,
 }
 
 const MAX_EXTENSION_LEDGERS: u32 = 10_000;
@@ -254,6 +225,29 @@ impl SkillSyncContract {
         env.events().publish(
             (symbol_short!("FundsLock"),),
             (buyer, session_id, amount),
+        );
+    }
+
+    // ── Issue #XXX: complete_session ───────────────────────────────────────────
+
+    /// Seller marks the session as delivered and moves it to Completed.
+    pub fn complete_session(env: Env, session_id: Bytes) {
+        let mut session: Session = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Session(session_id.clone()))
+            .expect("session not found");
+
+        session.seller.require_auth();
+        assert!(session.status == SessionStatus::Locked, "InvalidSessionState");
+
+        session.status = SessionStatus::Completed;
+        session.completed_at = env.ledger().sequence();
+        Self::save_session(&env, session_id.clone(), session);
+
+        env.events().publish(
+            (symbol_short!("SessComp"),),
+            (session_id, session.completed_at),
         );
     }
 
@@ -658,6 +652,37 @@ mod tests {
     fn test_uninitialized_set_dispute_window_reverts() {
         let (_, _admin, _treasury, client) = setup();
         client.set_dispute_window(&500);
+    }
+
+    // ── Issue #XXX: complete_session tests ─────────────────────────────────────
+
+    #[test]
+    fn test_complete_session_by_seller() {
+        use soroban_sdk::testutils::Events as _;
+        let (env, _admin, _treasury, client, session_id) = setup_with_session(1000);
+        let ledger_seq = env.ledger().sequence();
+        client.complete_session(&session_id);
+        let s = client.get_session(&session_id);
+        assert_eq!(s.status, SessionStatus::Completed);
+        assert_eq!(s.completed_at, ledger_seq);
+        let events = env.events().all();
+        assert!(events.len() >= 2, "SessionCompleted event not emitted");
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized")]
+    fn test_complete_session_non_seller_reverts() {
+        let (env, _admin, _treasury, client, session_id) = setup_with_session(1000);
+        let other = Address::generate(&env);
+        client.complete_session(&session_id).with_auth(&other);
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidSessionState")]
+    fn test_complete_session_on_non_locked_reverts() {
+        let (env, _admin, _treasury, client, session_id) = setup_with_session(1000);
+        client.complete_session(&session_id);
+        client.complete_session(&session_id);
     }
 
     // ── Issue #760: open_dispute tests ────────────────────────────────────────


### PR DESCRIPTION
closes #756 

### Description
This PR implements the `complete_session` function, allowing sellers to mark the delivery of goods/services and initiate the completion phase of the escrow session. This is a critical function in the escrow lifecycle that transitions sessions from `Locked` to `Completed` status.

