### PR TITLE
Feat/i gfor governo

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -96,3 +96,28 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 ## License
 
 Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+
+## Production hardening (quick notes)
+
+When deploying to production, ensure the following environment variables are set and never checked into source control:
+
+- `NODE_ENV`: set to `production` to enable production behaviour
+- `CORS_ALLOWED_ORIGINS`: comma-separated list of allowed front-end origins (e.g. `https://app.example.com,https://admin.example.com`)
+- `PORT`: port to listen on
+- `SWAGGER_USER` and `SWAGGER_PASS`: basic auth credentials to protect the Swagger UI (if exposing docs in production)
+- `SWAGGER_ENABLED`: set to `false` to disable Swagger entirely
+- `JWT_SECRET`, `DB_HOST`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD`, `DB_DATABASE`, `ENCRYPTION_KEY`, `ENCRYPTION_HMAC_KEY`, `REDIS_PASSWORD`, etc.
+
+Example (Unix/macOS):
+
+```bash
+NODE_ENV=production CORS_ALLOWED_ORIGINS="https://app.example.com" npm run build && npm run start:prod
+```
+
+Example (PowerShell/Windows):
+
+```powershell
+$env:NODE_ENV = 'production'; $env:CORS_ALLOWED_ORIGINS = 'https://app.example.com'; npm run build; npm run start:prod
+```
+
+Do not store secrets in code or commit `.env` files to the repository. Use your cloud provider's secret manager or a dedicated secrets store.

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "pg": "^8.22.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+     "helmet": "^7.0.0",
  feat/refresh-token
     "socket.io": "^4.8.3",
  main

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -26,7 +26,15 @@ const MSG_RATE_WINDOW_SECONDS = 60;
 const ONLINE_KEY_PREFIX = 'wsOnline';
 
 @WebSocketGateway({
-  cors: { origin: process.env.CORS_ORIGIN || '*', credentials: true },
+  cors: {
+    origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+      const raw = process.env.CORS_ALLOWED_ORIGINS || '';
+      const whitelist = raw.split(',').map((s) => s.trim()).filter(Boolean);
+      if (!origin) return callback(null, true);
+      return callback(null, whitelist.includes(origin));
+    },
+    credentials: true,
+  },
   namespace: '/chat',
   transports: ['websocket', 'polling'],
 })

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,6 +4,7 @@ import { Logger, ValidationPipe } from '@nestjs/common';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { join } from 'path';
 import * as express from 'express';
+import helmet from 'helmet';
 
 import { LoggingMiddleware } from './middleware/logging.middleware';
 import { RequestIdMiddleware } from './exceptions/request-id.middleware';
@@ -21,6 +22,20 @@ async function bootstrap() {
   const requestIdMiddleware = new RequestIdMiddleware();
 
   app.useWebSocketAdapter(new IoAdapter(app));
+  // Security: enable HTTP headers via Helmet
+  app.use(helmet());
+
+  // CORS: strict whitelist from `CORS_ALLOWED_ORIGINS` (comma-separated)
+  const rawCors = process.env.CORS_ALLOWED_ORIGINS || '';
+  const corsWhitelist = rawCors.split(',').map((s) => s.trim()).filter(Boolean);
+  app.enableCors({
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, true);
+      if (corsWhitelist.length === 0) return callback(new Error('CORS not configured'), false);
+      return callback(null, corsWhitelist.includes(origin));
+    },
+    credentials: true,
+  });
   app.use('/uploads', express.static(join(process.cwd(), 'uploads')));
   app.use(loggingMiddleware.use.bind(loggingMiddleware));
   app.use(requestIdMiddleware.use.bind(requestIdMiddleware));

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -51,6 +51,17 @@ async function bootstrap() {
 
   // Enable NestJS lifecycle shutdown hooks (OnModuleDestroy, etc.)
   app.enableShutdownHooks();
+  // Fail fast in production if critical secrets are missing
+  if (process.env.NODE_ENV === 'production') {
+    const missing: string[] = [];
+    if (!process.env.JWT_SECRET) missing.push('JWT_SECRET');
+    if (!process.env.ENCRYPTION_KEY) missing.push('ENCRYPTION_KEY');
+    if (!process.env.ENCRYPTION_HMAC_KEY) missing.push('ENCRYPTION_HMAC_KEY');
+    if (missing.length) {
+      logger.error(`Missing required environment variables for production: ${missing.join(', ')}`);
+      process.exit(1);
+    }
+  }
   // OpenAPI / Swagger UI (disabled in production via env flag)
   if (process.env.SWAGGER_ENABLED !== 'false') {
     setupSwagger(app);

--- a/backend/src/swagger/swagger.setup.ts
+++ b/backend/src/swagger/swagger.setup.ts
@@ -23,6 +23,33 @@ export function buildSwaggerDocument(app: INestApplication): OpenAPIObject {
 
 export function setupSwagger(app: INestApplication): void {
   const document = buildSwaggerDocument(app);
+  // In production, require basic auth to access the docs when configured.
+  if (process.env.NODE_ENV === 'production') {
+    const user = process.env.SWAGGER_USER;
+    const pass = process.env.SWAGGER_PASS;
+    if (!user || !pass) {
+      // Do not expose docs in production without credentials
+      return;
+    }
+
+    // Simple Basic Auth middleware for the swagger path
+    app.use(`/${SWAGGER_PATH}`, (req, res, next) => {
+      const auth = req.headers.authorization as string | undefined;
+      if (!auth || !auth.startsWith('Basic ')) {
+        res.setHeader('WWW-Authenticate', 'Basic realm="API Docs"');
+        return res.status(401).send('Authentication required');
+      }
+      try {
+        const creds = Buffer.from(auth.split(' ')[1], 'base64').toString();
+        const [u, p] = creds.split(':');
+        if (u === user && p === pass) return next();
+      } catch (e) {
+        // fallthrough to deny
+      }
+      return res.status(403).send('Forbidden');
+    });
+  }
+
   SwaggerModule.setup(SWAGGER_PATH, app, document, {
     swaggerOptions: {
       persistAuthorization: true,


### PR DESCRIPTION
Closes #729

implemented production hardening changes and updated the TODOs. Next: run installs/tests or review remaining hardcoded secrets.

What I changed

Helmet: added HTTP security headers in [main.ts:1-200](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/3cf8af2ee6/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Strict CORS: app-level whitelist from [CORS_ALLOWED_ORIGINS](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/3cf8af2ee6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [main.ts:1-200](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/3cf8af2ee6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and WebSocket gateway now uses the same whitelist in [chat.gateway.ts:1-200](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/3cf8af2ee6/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Swagger protection: Swagger setup now requires basic auth in production (uses [SWAGGER_USER](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/3cf8af2ee6/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[SWAGGER_PASS](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/3cf8af2ee6/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) and will not expose docs without credentials in [swagger.setup.ts:1-200](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/3cf8af2ee6/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Closes #730