### PR TITLE
feat: add escrow e2e lifecycle test and revoke-all-sessions service

### DIFF
--- a/backend/src/auth/revoke-all-sessions.service.ts
+++ b/backend/src/auth/revoke-all-sessions.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RefreshToken } from '../entities/refresh-token.entity';
+import { RedisService } from '../redis/redis.service';
+
+@Injectable()
+export class RevokeAllSessionsService {
+  constructor(
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokenRepo: Repository<RefreshToken>,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async revokeAllForUser(userId: string): Promise<{ revoked: number }> {
+    const tokens = await this.refreshTokenRepo.find({
+      where: { userId, isActive: true },
+    });
+
+    await this.refreshTokenRepo.update({ userId }, { isActive: false });
+
+    for (const token of tokens) {
+      if (token.jti) {
+        await this.redisService.set(`blacklist:jti:${token.jti}`, '1', 86400);
+      }
+    }
+
+    await this.redisService.incr(`token_version:${userId}`);
+
+    return { revoked: tokens.length };
+  }
+}

--- a/backend/test/escrow-lifecycle.e2e-spec.ts
+++ b/backend/test/escrow-lifecycle.e2e-spec.ts
@@ -1,0 +1,47 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Escrow Full Lifecycle (e2e) (#769)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(() => app.close());
+
+  it('lock → complete → approve → verify balances', async () => {
+    const lock = await request(app.getHttpServer()).post('/escrow/lock').send({ sessionId: 'e2e-1', amount: 100 });
+    expect(lock.status).toBe(201);
+    const complete = await request(app.getHttpServer()).post('/escrow/complete').send({ sessionId: 'e2e-1' });
+    expect(complete.status).toBe(200);
+    const approve = await request(app.getHttpServer()).post('/escrow/approve').send({ sessionId: 'e2e-1' });
+    expect(approve.status).toBe(200);
+    expect(approve.body.sellerBalance).toBeGreaterThan(0);
+  });
+
+  it('full lifecycle with refund path', async () => {
+    await request(app.getHttpServer()).post('/escrow/lock').send({ sessionId: 'e2e-2', amount: 100 });
+    const refund = await request(app.getHttpServer()).post('/escrow/refund').send({ sessionId: 'e2e-2' });
+    expect(refund.status).toBe(200);
+    expect(refund.body.refunded).toBe(true);
+  });
+
+  it('full lifecycle with dispute path', async () => {
+    await request(app.getHttpServer()).post('/escrow/lock').send({ sessionId: 'e2e-3', amount: 100 });
+    const dispute = await request(app.getHttpServer()).post('/escrow/dispute').send({ sessionId: 'e2e-3', reason: 'No show' });
+    expect(dispute.status).toBe(200);
+  });
+
+  it('fee accumulates correctly in treasury after approve', async () => {
+    const treasury = await request(app.getHttpServer()).get('/escrow/treasury/balance');
+    expect(treasury.status).toBe(200);
+    expect(typeof treasury.body.balance).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds end-to-end integration test covering the full escrow lifecycle
- Implements a service to revoke all active sessions for a user

## Changes
- `backend/test/escrow-lifecycle.e2e-spec.ts` — lock/complete/approve, refund path, dispute path, treasury fee check
- `backend/src/auth/revoke-all-sessions.service.ts` — invalidates all refresh tokens and increments token version

closes #769
closes #701