### PR TITLE
feat: add mentor and mentee profile entities

### DIFF
--- a/backend/src/users/entities/mentee-profile.entity.ts
+++ b/backend/src/users/entities/mentee-profile.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Column, CreateDateColumn, Entity,
+  JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+
+export enum SkillLevel {
+  BEGINNER = 'beginner',
+  INTERMEDIATE = 'intermediate',
+  ADVANCED = 'advanced',
+}
+
+@Entity('mentee_profiles')
+export class MenteeProfile {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column('simple-array', { nullable: true, name: 'learning_goals' })
+  learningGoals: string[];
+
+  @Column('simple-array', { nullable: true, name: 'areas_of_interest' })
+  areasOfInterest: string[];
+
+  @Column({ name: 'skill_level', type: 'enum', enum: SkillLevel, default: SkillLevel.BEGINNER })
+  skillLevel: SkillLevel;
+
+  @Column('simple-array', { nullable: true, name: 'preferred_mentoring_style' })
+  preferredMentoringStyle: string[];
+
+  @Column({ name: 'time_commitment_hours', type: 'int', nullable: true })
+  timeCommitmentHoursPerWeek: number;
+
+  @Column({ name: 'professional_background', type: 'text', nullable: true })
+  professionalBackground: string;
+
+  @Column({ name: 'job_title', nullable: true })
+  jobTitle: string;
+
+  @Column({ nullable: true })
+  industry: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/users/entities/mentor-profile.entity.ts
+++ b/backend/src/users/entities/mentor-profile.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Column, CreateDateColumn, Entity,
+  JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('mentor_profiles')
+export class MentorProfile {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'text', nullable: true })
+  bio: string;
+
+  @Column('simple-array', { nullable: true })
+  skills: string[];
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true, name: 'hourly_rate' })
+  hourlyRate: number;
+
+  @Column('simple-array', { nullable: true, name: 'expertise_areas' })
+  expertiseAreas: string[];
+
+  @Column({ name: 'years_of_experience', type: 'int', default: 0 })
+  yearsOfExperience: number;
+
+  @Column({ name: 'current_role', nullable: true })
+  currentRole: string;
+
+  @Column({ nullable: true })
+  company: string;
+
+  @Column({ name: 'is_verified', type: 'boolean', default: false })
+  isVerified: boolean;
+
+  @Column({ name: 'average_rating', type: 'decimal', precision: 3, scale: 2, default: 0 })
+  averageRating: number;
+
+  @Column({ name: 'total_mentoring_hours', type: 'int', default: 0 })
+  totalMentoringHours: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Summary
- Adds `MentorProfile` TypeORM entity with professional and verification fields
- Adds `MenteeProfile` TypeORM entity with learning goals and skill level

## Changes
- `backend/src/users/entities/mentor-profile.entity.ts` — bio, skills, hourly rate, expertise, rating
- `backend/src/users/entities/mentee-profile.entity.ts` — learning goals, skill level enum, mentoring style

closes #705
closes #706