### PR TITLE
feat: add users controller and user profile migration

### DIFF
--- a/backend/src/database/migrations/1750300000000-AddUserProfileFields.ts
+++ b/backend/src/database/migrations/1750300000000-AddUserProfileFields.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+export class AddUserProfileFields1750300000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('users', [
+      { name: 'display_name', type: 'varchar', length: '100', isNullable: true } as any,
+      { name: 'email', type: 'varchar', length: '255', isNullable: true } as any,
+      { name: 'status', type: 'varchar', length: '20', default: "'active'" } as any,
+      { name: 'avatar_url', type: 'varchar', length: '512', isNullable: true } as any,
+      { name: 'timezone', type: 'varchar', length: '50', isNullable: true } as any,
+      { name: 'locale', type: 'varchar', length: '10', isNullable: true } as any,
+      { name: 'last_login_at', type: 'timestamptz', isNullable: true } as any,
+      { name: 'deleted_at', type: 'timestamptz', isNullable: true } as any,
+    ]);
+
+    await queryRunner.createIndex('users', new TableIndex({
+      name: 'IDX_users_status',
+      columnNames: ['status'],
+    }));
+
+    await queryRunner.createIndex('users', new TableIndex({
+      name: 'IDX_users_email',
+      columnNames: ['email'],
+      isUnique: true,
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('users', 'IDX_users_status');
+    await queryRunner.dropIndex('users', 'IDX_users_email');
+    await queryRunner.dropColumns('users', [
+      'display_name', 'email', 'status', 'avatar_url', 'timezone', 'locale', 'last_login_at', 'deleted_at',
+    ]);
+  }
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../jwt-auth.guard';
+import { UsersService } from './users.service';
+
+@ApiTags('users')
+@Controller('users')
+@UseGuards(JwtAuthGuard)
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get user by ID' })
+  @ApiResponse({ status: 200, description: 'User found' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async getUser(@Param('id') id: string) {
+    return this.usersService.findById(id);
+  }
+
+  @Get(':id/profile')
+  @ApiOperation({ summary: 'Get full user profile' })
+  @ApiResponse({ status: 200, description: 'User profile returned' })
+  async getProfile(@Param('id') id: string) {
+    return this.usersService.findById(id);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `UsersController` with GET user and GET user profile endpoints
- Adds migration to extend the users table with profile fields

## Changes
- `backend/src/users/users.controller.ts` — GET /users/:id and GET /users/:id/profile
- `backend/src/database/migrations/1750300000000-AddUserProfileFields.ts` — adds display_name, email, status, avatar_url, timezone, soft-delete

closes #703
closes #704