### PR TITLE
feat: add profile completeness service and auth swagger DTOs

### DIFF
--- a/backend/src/auth/dto/auth-swagger.dto.ts
+++ b/backend/src/auth/dto/auth-swagger.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class LoginRequestDto {
+  @ApiProperty({ example: 'GABC...XYZ', description: 'Stellar wallet public key' })
+  @IsString() @IsNotEmpty()
+  walletAddress: string;
+
+  @ApiProperty({ example: 'abc123nonce', description: 'One-time nonce retrieved from /auth/nonce' })
+  @IsString() @IsNotEmpty()
+  nonce: string;
+
+  @ApiProperty({ example: 'MEUC...base64signature', description: 'Ed25519 signature of the nonce' })
+  @IsString() @IsNotEmpty()
+  signature: string;
+}
+
+export class LoginResponseDto {
+  @ApiProperty({ example: 'eyJhbGci...', description: 'JWT access token' })
+  accessToken: string;
+
+  @ApiProperty({ example: 'dGhpcyBp...', description: 'Refresh token for session renewal' })
+  refreshToken: string;
+
+  @ApiProperty({ example: 3600, description: 'Access token expiry in seconds' })
+  expiresIn: number;
+}
+
+export class RefreshRequestDto {
+  @ApiProperty({ example: 'dGhpcyBp...', description: 'Valid refresh token' })
+  @IsString() @IsNotEmpty()
+  refreshToken: string;
+}
+
+export class NonceResponseDto {
+  @ApiProperty({ example: 'abc123nonce', description: 'One-time challenge nonce to sign' })
+  nonce: string;
+
+  @ApiProperty({ example: 300, description: 'Nonce validity window in seconds' })
+  expiresIn: number;
+}

--- a/backend/src/users/profile-completeness.service.ts
+++ b/backend/src/users/profile-completeness.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+
+interface ProfileFields {
+  bio?: string; skills?: string[]; hourlyRate?: number;
+  expertiseAreas?: string[]; avatarUrl?: string; availabilitySlots?: any[];
+  learningGoals?: string[]; skillLevel?: string; areasOfInterest?: string[];
+  portfolio?: string; education?: any[]; certifications?: any[];
+}
+
+@Injectable()
+export class ProfileCompletenessService {
+  private isPresent(value: any): boolean {
+    if (value === undefined || value === null) return false;
+    if (Array.isArray(value)) return value.length > 0;
+    return true;
+  }
+
+  computeScore(profileType: 'mentor' | 'mentee', fields: ProfileFields): number {
+    const mentorRequired = ['bio', 'skills', 'hourlyRate', 'expertiseAreas', 'avatarUrl', 'availabilitySlots'];
+    const menteeRequired = ['learningGoals', 'skillLevel', 'areasOfInterest'];
+    const optional = ['portfolio', 'education', 'certifications'];
+
+    const required = profileType === 'mentor' ? mentorRequired : menteeRequired;
+    const filledRequired = required.filter(f => this.isPresent(fields[f as keyof ProfileFields]));
+    let score = (filledRequired.length / required.length) * 100;
+
+    const filledOptional = optional.filter(f => this.isPresent(fields[f as keyof ProfileFields]));
+    score += filledOptional.length * (10 / optional.length);
+
+    return Math.min(Math.round(score), 110);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds ProfileCompletenessService to compute a 0-110% completion score
- Adds Swagger-decorated DTOs for all auth endpoints

## Changes
- backend/src/users/profile-completeness.service.ts
- backend/src/auth/dto/auth-swagger.dto.ts

closes #721
closes #702