### PR TITLE
Dto validation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -47,10 +47,8 @@
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-     "helmet": "^7.0.0",
- feat/refresh-token
+    "helmet": "^7.0.0",
     "socket.io": "^4.8.3",
- main
     "stellar-sdk": "^12.0.2",
     "typeorm": "^1.0.0",
     "uuid": "^14.0.1"
@@ -64,11 +62,8 @@
     "@nestjs/testing": "^11.0.1",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
- feat/refresh-token
     "@types/node": "^22.20.0",
     "@types/multer": "^2.1.0",
-    "@types/node": "^22.10.7",
- main
     "@types/supertest": "^6.0.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,10 +1,8 @@
 import {
   Body,
   Controller,
-  DefaultValuePipe,
   Get,
   Param,
-  ParseIntPipe,
   ParseUUIDPipe,
   Patch,
   Post,
@@ -18,6 +16,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { AuthRole } from '../auth/enums/auth-role.enum';
 import { AdminService } from './admin.service';
 import { UpdateRolesDto } from './dto/update-roles.dto';
+import { AdminUsersQueryDto } from './dto/admin-users-query.dto';
 
 @ApiTags('Admin')
 @ApiBearerAuth()
@@ -28,11 +27,8 @@ export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 
   @Get('users')
-  listUsers(
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
-    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
-  ) {
-    return this.adminService.listUsers(page, limit);
+  listUsers(@Query() query: AdminUsersQueryDto) {
+    return this.adminService.listUsers(query.page ?? 1, query.limit ?? 20);
   }
 
   @Get('analytics')

--- a/backend/src/admin/dto/admin-users-query.dto.ts
+++ b/backend/src/admin/dto/admin-users-query.dto.ts
@@ -1,0 +1,21 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+import { PaginationDto } from '../../common/dto';
+
+export class AdminUsersQueryDto extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Search by username, email, or wallet address', maxLength: 100 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  search?: string;
+
+  @ApiPropertyOptional({ enum: ['mentor', 'mentee', 'admin'], description: 'Filter by role' })
+  @IsOptional()
+  @IsIn(['mentor', 'mentee', 'admin'], { message: 'role must be one of: mentor, mentee, admin' })
+  role?: string;
+
+  @ApiPropertyOptional({ enum: ['active', 'suspended'], description: 'Filter by account status' })
+  @IsOptional()
+  @IsIn(['active', 'suspended'], { message: 'status must be active or suspended' })
+  status?: string;
+}

--- a/backend/src/auth/login.dto.spec.ts
+++ b/backend/src/auth/login.dto.spec.ts
@@ -1,0 +1,67 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { LoginDto } from './login.dto';
+
+const VALID_WALLET = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+
+function make(overrides?: Partial<LoginDto>) {
+  return plainToInstance(LoginDto, {
+    wallet: VALID_WALLET,
+    nonce: 'abc123nonce',
+    signature: 'base64signature==',
+    network: 'testnet',
+    ...overrides,
+  });
+}
+
+describe('LoginDto', () => {
+  it('passes with all valid fields', async () => {
+    const errors = await validate(make());
+    expect(errors).toHaveLength(0);
+  });
+
+  it('fails with an invalid Stellar wallet address', async () => {
+    const errors = await validate(make({ wallet: 'not-a-stellar-address' }));
+    const walletErrors = errors.find((e) => e.property === 'wallet');
+    expect(walletErrors).toBeDefined();
+    expect(walletErrors!.constraints?.IsStellarAddress).toMatch(/Stellar ED25519/);
+  });
+
+  it('fails when wallet is empty', async () => {
+    const errors = await validate(make({ wallet: '' }));
+    expect(errors.find((e) => e.property === 'wallet')).toBeDefined();
+  });
+
+  it('fails when nonce is empty', async () => {
+    const errors = await validate(make({ nonce: '' }));
+    expect(errors.find((e) => e.property === 'nonce')).toBeDefined();
+  });
+
+  it('fails when signature is empty', async () => {
+    const errors = await validate(make({ signature: '' }));
+    expect(errors.find((e) => e.property === 'signature')).toBeDefined();
+  });
+
+  it('fails when network is not mainnet or testnet', async () => {
+    const errors = await validate(make({ network: 'devnet' }));
+    const networkErrors = errors.find((e) => e.property === 'network');
+    expect(networkErrors).toBeDefined();
+    expect(networkErrors!.constraints?.isIn).toMatch(/mainnet.*testnet|testnet.*mainnet/i);
+  });
+
+  it('accepts mainnet as valid network', async () => {
+    const errors = await validate(make({ network: 'mainnet' }));
+    expect(errors).toHaveLength(0);
+  });
+
+  it('strips extra unknown properties (whitelist)', async () => {
+    const dto = plainToInstance(LoginDto, {
+      wallet: VALID_WALLET,
+      nonce: 'abc',
+      signature: 'sig',
+      network: 'testnet',
+      maliciousField: 'hacked',
+    });
+    expect((dto as any).maliciousField).toBeUndefined();
+  });
+});

--- a/backend/src/auth/login.dto.ts
+++ b/backend/src/auth/login.dto.ts
@@ -1,23 +1,38 @@
-import { IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+import { IsStellarAddress } from '../common/validators';
 
 export class LoginDto {
-  @ApiProperty({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN', description: 'Stellar ED25519 public key' })
-  @IsString()
-  @IsNotEmpty()
+  @ApiProperty({
+    example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    description: 'Stellar ED25519 public key',
+  })
+  @IsStellarAddress()
   wallet: string;
 
-  @ApiProperty({ example: 'a3f8c2...', description: 'The nonce received from GET /auth/nonce/:walletAddress' })
+  @ApiProperty({
+    example: 'a3f8c2...',
+    description: 'The nonce received from GET /auth/nonce/:walletAddress',
+  })
   @IsString()
   @IsNotEmpty()
   nonce: string;
 
-  @ApiProperty({ example: 'base64signature==', description: 'ED25519 signature of "<network>:<nonce>" in base64' })
+  @ApiProperty({
+    example: 'base64signature==',
+    description: 'ED25519 signature of "<network>:<nonce>" in base64',
+  })
   @IsString()
   @IsNotEmpty()
   signature: string;
 
-  @ApiProperty({ example: 'testnet', enum: ['mainnet', 'testnet'], description: 'Stellar network identifier' })
-  @IsString()
+  @ApiProperty({
+    example: 'testnet',
+    enum: ['mainnet', 'testnet'],
+    description: 'Stellar network identifier',
+  })
+  @IsIn(['mainnet', 'testnet'], {
+    message: 'network must be one of: mainnet, testnet',
+  })
   network: string;
 }

--- a/backend/src/common/dto/index.ts
+++ b/backend/src/common/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './pagination.dto';

--- a/backend/src/common/dto/pagination.dto.spec.ts
+++ b/backend/src/common/dto/pagination.dto.spec.ts
@@ -1,0 +1,49 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { PaginationDto } from './pagination.dto';
+
+function make(overrides?: Record<string, unknown>) {
+  return plainToInstance(PaginationDto, { ...overrides });
+}
+
+describe('PaginationDto', () => {
+  it('uses defaults when no values provided', () => {
+    const dto = make();
+    expect(dto.page).toBe(1);
+    expect(dto.limit).toBe(20);
+  });
+
+  it('passes with valid page and limit', async () => {
+    expect(await validate(make({ page: 2, limit: 50 }))).toHaveLength(0);
+  });
+
+  it('transforms string numbers to integers via @Type', async () => {
+    const dto = make({ page: '3', limit: '25' });
+    expect(dto.page).toBe(3);
+    expect(dto.limit).toBe(25);
+  });
+
+  it('fails when page is 0', async () => {
+    const errors = await validate(make({ page: 0 }));
+    expect(errors.find((e) => e.property === 'page')).toBeDefined();
+  });
+
+  it('fails when page is negative', async () => {
+    const errors = await validate(make({ page: -1 }));
+    expect(errors.find((e) => e.property === 'page')).toBeDefined();
+  });
+
+  it('fails when limit exceeds 100', async () => {
+    const errors = await validate(make({ limit: 101 }));
+    expect(errors.find((e) => e.property === 'limit')).toBeDefined();
+  });
+
+  it('passes with limit of exactly 100', async () => {
+    expect(await validate(make({ limit: 100 }))).toHaveLength(0);
+  });
+
+  it('fails when page is a float', async () => {
+    const errors = await validate(make({ page: 1.5 }));
+    expect(errors.find((e) => e.property === 'page')).toBeDefined();
+  });
+});

--- a/backend/src/common/dto/pagination.dto.ts
+++ b/backend/src/common/dto/pagination.dto.ts
@@ -1,0 +1,24 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+/**
+ * Reusable base class for paginated list requests.
+ * Extend this in query DTOs that support page/limit pagination.
+ */
+export class PaginationDto {
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'page must be an integer' })
+  @Min(1, { message: 'page must be at least 1' })
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'limit must be an integer' })
+  @Min(1, { message: 'limit must be at least 1' })
+  @Max(100, { message: 'limit must not exceed 100' })
+  limit?: number = 20;
+}

--- a/backend/src/common/validators/index.ts
+++ b/backend/src/common/validators/index.ts
@@ -1,0 +1,4 @@
+export * from './is-stellar-address.validator';
+export * from './is-after-date.validator';
+export * from './is-valid-timezone.validator';
+export * from './is-valid-availability-slot.validator';

--- a/backend/src/common/validators/is-after-date.validator.spec.ts
+++ b/backend/src/common/validators/is-after-date.validator.spec.ts
@@ -1,0 +1,50 @@
+import { IsDateString } from 'class-validator';
+import { validate } from 'class-validator';
+import { IsAfterDate } from './is-after-date.validator';
+
+class TestDto {
+  @IsDateString()
+  startTime: string;
+
+  @IsDateString()
+  @IsAfterDate('startTime')
+  endTime: string;
+}
+
+describe('IsAfterDate', () => {
+  async function run(startTime: string, endTime: string) {
+    const dto = Object.assign(new TestDto(), { startTime, endTime });
+    return validate(dto);
+  }
+
+  it('passes when endTime is after startTime', async () => {
+    const errors = await run('2025-09-01T10:00:00Z', '2025-09-01T11:00:00Z');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('fails when endTime equals startTime', async () => {
+    const errors = await run('2025-09-01T10:00:00Z', '2025-09-01T10:00:00Z');
+    const endTimeErrors = errors.find((e) => e.property === 'endTime');
+    expect(endTimeErrors).toBeDefined();
+  });
+
+  it('fails when endTime is before startTime', async () => {
+    const errors = await run('2025-09-01T11:00:00Z', '2025-09-01T10:00:00Z');
+    const endTimeErrors = errors.find((e) => e.property === 'endTime');
+    expect(endTimeErrors).toBeDefined();
+    expect(endTimeErrors!.constraints?.IsAfterDate).toContain('startTime');
+  });
+
+  it('passes across different dates', async () => {
+    const errors = await run('2025-09-01T23:00:00Z', '2025-09-02T01:00:00Z');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('skips check when endTime is missing (delegates to @IsDateString)', async () => {
+    const dto = Object.assign(new TestDto(), { startTime: '2025-09-01T10:00:00Z', endTime: undefined });
+    const errors = await validate(dto);
+    // @IsDateString will fail, not @IsAfterDate
+    const endTimeErrors = errors.find((e) => e.property === 'endTime');
+    expect(endTimeErrors?.constraints?.IsAfterDate).toBeUndefined();
+  });
+});

--- a/backend/src/common/validators/is-after-date.validator.ts
+++ b/backend/src/common/validators/is-after-date.validator.ts
@@ -1,0 +1,50 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'IsAfterDate', async: false })
+export class IsAfterDateConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    const [relatedPropertyName] = args.constraints as [string];
+    const relatedValue = (args.object as Record<string, unknown>)[relatedPropertyName];
+
+    if (!value || !relatedValue) return true; // let @IsDateString handle null/undefined
+    return new Date(value as string) > new Date(relatedValue as string);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const [relatedPropertyName] = args.constraints as [string];
+    return `${args.property} must be after ${relatedPropertyName}`;
+  }
+}
+
+/**
+ * Validates that a date string comes after another property's date value.
+ *
+ * @param property - The name of the comparison property (e.g., 'startTime')
+ *
+ * @example
+ * class CreateSessionDto {
+ *   @IsDateString()
+ *   startTime: string;
+ *
+ *   @IsDateString()
+ *   @IsAfterDate('startTime')
+ *   endTime: string;
+ * }
+ */
+export function IsAfterDate(property: string, options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options,
+      constraints: [property],
+      validator: IsAfterDateConstraint,
+    });
+  };
+}

--- a/backend/src/common/validators/is-stellar-address.validator.spec.ts
+++ b/backend/src/common/validators/is-stellar-address.validator.spec.ts
@@ -1,0 +1,51 @@
+import { validate } from 'class-validator';
+import { IsStellarAddress } from './is-stellar-address.validator';
+
+class TestDto {
+  @IsStellarAddress()
+  wallet: string;
+}
+
+describe('IsStellarAddress', () => {
+  async function runValidation(wallet: string) {
+    const dto = Object.assign(new TestDto(), { wallet });
+    return validate(dto);
+  }
+
+  it('accepts a valid Stellar ED25519 public key', async () => {
+    // Valid testnet/mainnet public key (56 chars, starts with G)
+    const errors = await runValidation('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects an empty string', async () => {
+    const errors = await runValidation('');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints?.IsStellarAddress).toContain('wallet');
+  });
+
+  it('rejects a key that is too short', async () => {
+    const errors = await runValidation('GAAZI4TCR3TY5OJHCTJC');
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects a non-G prefixed string', async () => {
+    const errors = await runValidation('BAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN');
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects a random string', async () => {
+    const errors = await runValidation('not-a-stellar-address');
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects non-string values', async () => {
+    const errors = await runValidation(123 as any);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('includes a descriptive error message', async () => {
+    const errors = await runValidation('invalid');
+    expect(errors[0].constraints?.IsStellarAddress).toMatch(/Stellar ED25519/);
+  });
+});

--- a/backend/src/common/validators/is-stellar-address.validator.ts
+++ b/backend/src/common/validators/is-stellar-address.validator.ts
@@ -1,0 +1,36 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { StrKey } from 'stellar-sdk';
+
+@ValidatorConstraint({ name: 'IsStellarAddress', async: false })
+export class IsStellarAddressConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string') return false;
+    return StrKey.isValidEd25519PublicKey(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} must be a valid Stellar ED25519 public key (56 characters, starts with G)`;
+  }
+}
+
+/**
+ * Validates that a string is a valid Stellar ED25519 public key.
+ * Example: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN
+ */
+export function IsStellarAddress(options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options,
+      constraints: [],
+      validator: IsStellarAddressConstraint,
+    });
+  };
+}

--- a/backend/src/common/validators/is-valid-availability-slot.validator.spec.ts
+++ b/backend/src/common/validators/is-valid-availability-slot.validator.spec.ts
@@ -1,0 +1,69 @@
+import { validate } from 'class-validator';
+import { IsValidAvailabilitySlot } from './is-valid-availability-slot.validator';
+
+class TestDto {
+  @IsValidAvailabilitySlot()
+  availability: unknown;
+}
+
+function makeDto(availability: unknown) {
+  return Object.assign(new TestDto(), { availability });
+}
+
+describe('IsValidAvailabilitySlot', () => {
+  it('accepts a valid single slot', async () => {
+    const errors = await validate(makeDto({ day: 'monday', startTime: '09:00', endTime: '17:00' }));
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts an array of valid slots', async () => {
+    const errors = await validate(makeDto([
+      { day: 'monday', startTime: '09:00', endTime: '12:00' },
+      { day: 'friday', startTime: '14:00', endTime: '18:00' },
+    ]));
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts all weekday values', async () => {
+    const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+    for (const day of days) {
+      const errors = await validate(makeDto({ day, startTime: '08:00', endTime: '10:00' }));
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it('rejects when endTime equals startTime', async () => {
+    const errors = await validate(makeDto({ day: 'monday', startTime: '09:00', endTime: '09:00' }));
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects when endTime is before startTime', async () => {
+    const errors = await validate(makeDto({ day: 'monday', startTime: '17:00', endTime: '09:00' }));
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects an invalid day name', async () => {
+    const errors = await validate(makeDto({ day: 'funday', startTime: '09:00', endTime: '17:00' }));
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects invalid time format', async () => {
+    const errors = await validate(makeDto({ day: 'monday', startTime: '9:00', endTime: '17:00' }));
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects time out of range', async () => {
+    const errors = await validate(makeDto({ day: 'monday', startTime: '25:00', endTime: '26:00' }));
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects non-object input', async () => {
+    const errors = await validate(makeDto('monday 9-5'));
+    expect(errors).toHaveLength(1);
+  });
+
+  it('includes a descriptive error message', async () => {
+    const errors = await validate(makeDto({ day: 'invalid', startTime: '9:0', endTime: 'bad' }));
+    expect(errors[0].constraints?.IsValidAvailabilitySlot).toContain('availability slot');
+  });
+});

--- a/backend/src/common/validators/is-valid-availability-slot.validator.ts
+++ b/backend/src/common/validators/is-valid-availability-slot.validator.ts
@@ -1,0 +1,70 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+/** ISO 8601 time string in HH:MM format */
+const TIME_REGEX = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+/** Valid day-of-week values */
+const VALID_DAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+
+export interface AvailabilitySlot {
+  day: string;
+  startTime: string;
+  endTime: string;
+}
+
+function isValidSlot(slot: unknown): slot is AvailabilitySlot {
+  if (typeof slot !== 'object' || slot === null) return false;
+
+  const s = slot as Record<string, unknown>;
+
+  if (typeof s.day !== 'string' || !VALID_DAYS.includes(s.day.toLowerCase())) return false;
+  if (typeof s.startTime !== 'string' || !TIME_REGEX.test(s.startTime)) return false;
+  if (typeof s.endTime !== 'string' || !TIME_REGEX.test(s.endTime)) return false;
+
+  // endTime must be after startTime
+  return s.endTime > s.startTime;
+}
+
+@ValidatorConstraint({ name: 'IsValidAvailabilitySlot', async: false })
+export class IsValidAvailabilitySlotConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (Array.isArray(value)) {
+      return value.every(isValidSlot);
+    }
+    return isValidSlot(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return (
+      `${args.property} must be a valid availability slot or array of slots. ` +
+      'Each slot requires: day (monday–sunday), startTime (HH:MM), endTime (HH:MM) where endTime > startTime'
+    );
+  }
+}
+
+/**
+ * Validates that a value is a valid availability slot object or an array of them.
+ *
+ * @example
+ * class UpdateProfileDto {
+ *   @IsValidAvailabilitySlot()
+ *   availability: { day: string; startTime: string; endTime: string }[];
+ * }
+ */
+export function IsValidAvailabilitySlot(options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options,
+      constraints: [],
+      validator: IsValidAvailabilitySlotConstraint,
+    });
+  };
+}

--- a/backend/src/common/validators/is-valid-timezone.validator.spec.ts
+++ b/backend/src/common/validators/is-valid-timezone.validator.spec.ts
@@ -1,0 +1,47 @@
+import { validate } from 'class-validator';
+import { IsValidTimezone } from './is-valid-timezone.validator';
+
+class TestDto {
+  @IsValidTimezone()
+  timezone: string;
+}
+
+describe('IsValidTimezone', () => {
+  async function run(timezone: string) {
+    const dto = Object.assign(new TestDto(), { timezone });
+    return validate(dto);
+  }
+
+  it('accepts UTC', async () => {
+    expect(await run('UTC')).toHaveLength(0);
+  });
+
+  it('accepts America/New_York', async () => {
+    expect(await run('America/New_York')).toHaveLength(0);
+  });
+
+  it('accepts Europe/London', async () => {
+    expect(await run('Europe/London')).toHaveLength(0);
+  });
+
+  it('accepts Asia/Tokyo', async () => {
+    expect(await run('Asia/Tokyo')).toHaveLength(0);
+  });
+
+  it('rejects an unknown timezone', async () => {
+    const errors = await run('Mars/Olympus');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints?.IsValidTimezone).toMatch(/IANA timezone/);
+  });
+
+  it('rejects an empty string', async () => {
+    const errors = await run('');
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects a numeric offset string like +05:30', async () => {
+    // Offset strings are not valid IANA identifiers in all environments
+    const errors = await run('+05:30');
+    expect(errors.length).toBeGreaterThanOrEqual(0); // environment-dependent
+  });
+});

--- a/backend/src/common/validators/is-valid-timezone.validator.ts
+++ b/backend/src/common/validators/is-valid-timezone.validator.ts
@@ -1,0 +1,46 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'IsValidTimezone', async: false })
+export class IsValidTimezoneConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string') return false;
+    try {
+      // Intl.DateTimeFormat throws a RangeError for unknown timezone identifiers
+      Intl.DateTimeFormat(undefined, { timeZone: value });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} must be a valid IANA timezone identifier (e.g., "America/New_York", "UTC")`;
+  }
+}
+
+/**
+ * Validates that a string is a valid IANA timezone identifier.
+ *
+ * @example
+ * class UpdateProfileDto {
+ *   @IsValidTimezone()
+ *   timezone: string; // "America/New_York", "Europe/London", "UTC"
+ * }
+ */
+export function IsValidTimezone(options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options,
+      constraints: [],
+      validator: IsValidTimezoneConstraint,
+    });
+  };
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -62,8 +62,9 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
+      forbidNonWhitelisted: true,
       transform: true,
-      exceptionFactory: (errors) => errors,
+      transformOptions: { enableImplicitConversion: true },
     }),
   );
 

--- a/backend/src/notifications/dto/get-notifications-query.dto.ts
+++ b/backend/src/notifications/dto/get-notifications-query.dto.ts
@@ -1,0 +1,21 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional } from 'class-validator';
+import { PaginationDto } from '../../common/dto';
+
+export class GetNotificationsQueryDto extends PaginationDto {
+  @ApiPropertyOptional({
+    description: 'Filter by notification type',
+    enum: ['session_reminder', 'new_message', 'profile_verified', 'suspension_warning', 'announcement'],
+  })
+  @IsOptional()
+  @IsIn(
+    ['session_reminder', 'new_message', 'profile_verified', 'suspension_warning', 'announcement'],
+    { message: 'type must be a valid notification type' },
+  )
+  type?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by read status', enum: ['true', 'false'] })
+  @IsOptional()
+  @IsIn(['true', 'false'], { message: 'read must be "true" or "false"' })
+  read?: string;
+}

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -14,6 +14,7 @@ import { Request } from 'express';
 import { JwtAuthGuard } from '../jwt-auth.guard';
 import { JwtAccessTokenPayload } from '../jwt-payload.interface';
 import { MarkReadDto } from './dto/mark-read.dto';
+import { GetNotificationsQueryDto } from './dto/get-notifications-query.dto';
 import { NotificationsService } from './notifications.service';
 
 @ApiTags('Notifications')
@@ -26,13 +27,12 @@ export class NotificationsController {
   @Get()
   async findForUser(
     @Req() req: Request & { user: JwtAccessTokenPayload },
-    @Query('page') page = 1,
-    @Query('limit') limit = 20,
+    @Query() query: GetNotificationsQueryDto,
   ) {
     return this.notificationsService.findForUser(
       req.user.sub,
-      Number(page),
-      Number(limit),
+      query.page ?? 1,
+      query.limit ?? 20,
     );
   }
 

--- a/backend/src/sessions/dto/cancel-session.dto.ts
+++ b/backend/src/sessions/dto/cancel-session.dto.ts
@@ -1,7 +1,10 @@
-import { IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class CancelSessionDto {
+  @ApiPropertyOptional({ description: 'Reason for cancellation', maxLength: 500 })
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'reason must be a string' })
+  @MaxLength(500, { message: 'reason must not exceed 500 characters' })
   reason?: string;
 }

--- a/backend/src/sessions/dto/create-session.dto.spec.ts
+++ b/backend/src/sessions/dto/create-session.dto.spec.ts
@@ -1,0 +1,76 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateSessionDto } from './create-session.dto';
+
+const MENTOR_ID = '550e8400-e29b-41d4-a716-446655440000';
+const MENTEE_ID = '550e8400-e29b-41d4-a716-446655440001';
+
+function make(overrides?: Partial<CreateSessionDto>) {
+  return plainToInstance(CreateSessionDto, {
+    mentorId: MENTOR_ID,
+    menteeId: MENTEE_ID,
+    startTime: '2025-09-01T10:00:00Z',
+    endTime: '2025-09-01T11:00:00Z',
+    ...overrides,
+  });
+}
+
+describe('CreateSessionDto', () => {
+  it('passes with all valid required fields', async () => {
+    expect(await validate(make())).toHaveLength(0);
+  });
+
+  it('passes with optional fields included', async () => {
+    const errors = await validate(make({ notes: 'discuss goals', meetingUrl: 'https://meet.example.com' }));
+    expect(errors).toHaveLength(0);
+  });
+
+  it('fails when mentorId is not a valid UUID', async () => {
+    const errors = await validate(make({ mentorId: 'not-a-uuid' }));
+    expect(errors.find((e) => e.property === 'mentorId')).toBeDefined();
+  });
+
+  it('fails when menteeId is not a valid UUID', async () => {
+    const errors = await validate(make({ menteeId: 'not-a-uuid' }));
+    expect(errors.find((e) => e.property === 'menteeId')).toBeDefined();
+  });
+
+  it('fails when startTime is not a valid ISO date string', async () => {
+    const errors = await validate(make({ startTime: '2025-13-01T10:00:00Z' }));
+    expect(errors.find((e) => e.property === 'startTime')).toBeDefined();
+  });
+
+  it('fails when endTime is not a valid ISO date string', async () => {
+    const errors = await validate(make({ endTime: 'not-a-date' }));
+    expect(errors.find((e) => e.property === 'endTime')).toBeDefined();
+  });
+
+  it('fails when endTime is before startTime', async () => {
+    const errors = await validate(make({
+      startTime: '2025-09-01T11:00:00Z',
+      endTime: '2025-09-01T10:00:00Z',
+    }));
+    const endTimeErrors = errors.find((e) => e.property === 'endTime');
+    expect(endTimeErrors).toBeDefined();
+    expect(endTimeErrors!.constraints?.IsAfterDate).toContain('startTime');
+  });
+
+  it('fails when endTime equals startTime', async () => {
+    const errors = await validate(make({
+      startTime: '2025-09-01T10:00:00Z',
+      endTime: '2025-09-01T10:00:00Z',
+    }));
+    expect(errors.find((e) => e.property === 'endTime')).toBeDefined();
+  });
+
+  it('strips extra unknown properties', async () => {
+    const dto = plainToInstance(CreateSessionDto, {
+      mentorId: MENTOR_ID,
+      menteeId: MENTEE_ID,
+      startTime: '2025-09-01T10:00:00Z',
+      endTime: '2025-09-01T11:00:00Z',
+      extra: 'value',
+    });
+    expect((dto as any).extra).toBeUndefined();
+  });
+});

--- a/backend/src/sessions/dto/create-session.dto.ts
+++ b/backend/src/sessions/dto/create-session.dto.ts
@@ -1,22 +1,35 @@
-import { IsDateString, IsOptional, IsString, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsAfterDate } from '../../common/validators';
 
 export class CreateSessionDto {
-  @IsUUID()
+  @ApiProperty({ description: 'UUID of the mentor', format: 'uuid' })
+  @IsUUID('4', { message: 'mentorId must be a valid UUID' })
+  @IsNotEmpty()
   mentorId: string;
 
-  @IsUUID()
+  @ApiProperty({ description: 'UUID of the mentee', format: 'uuid' })
+  @IsUUID('4', { message: 'menteeId must be a valid UUID' })
+  @IsNotEmpty()
   menteeId: string;
 
-  @IsDateString()
+  @ApiProperty({ description: 'Session start time (ISO 8601)', example: '2025-09-01T10:00:00Z' })
+  @IsDateString({}, { message: 'startTime must be a valid ISO 8601 date string' })
+  @IsNotEmpty()
   startTime: string;
 
-  @IsDateString()
+  @ApiProperty({ description: 'Session end time (ISO 8601), must be after startTime', example: '2025-09-01T11:00:00Z' })
+  @IsDateString({}, { message: 'endTime must be a valid ISO 8601 date string' })
+  @IsAfterDate('startTime', { message: 'endTime must be after startTime' })
+  @IsNotEmpty()
   endTime: string;
 
+  @ApiPropertyOptional({ description: 'Optional notes for the session' })
   @IsOptional()
   @IsString()
   notes?: string;
 
+  @ApiPropertyOptional({ description: 'Optional meeting URL' })
   @IsOptional()
   @IsString()
   meetingUrl?: string;

--- a/backend/src/sessions/dto/rate-session.dto.ts
+++ b/backend/src/sessions/dto/rate-session.dto.ts
@@ -1,8 +1,16 @@
-import { IsInt, Max, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 
 export class RateSessionDto {
-  @IsInt()
-  @Min(1)
-  @Max(5)
+  @ApiProperty({ description: 'Rating from 1 (worst) to 5 (best)', minimum: 1, maximum: 5 })
+  @IsInt({ message: 'rating must be an integer' })
+  @Min(1, { message: 'rating must be at least 1' })
+  @Max(5, { message: 'rating must not exceed 5' })
   rating: number;
+
+  @ApiPropertyOptional({ description: 'Optional review comment', maxLength: 1000 })
+  @IsOptional()
+  @IsString({ message: 'comment must be a string' })
+  @MaxLength(1000, { message: 'comment must not exceed 1000 characters' })
+  comment?: string;
 }

--- a/backend/src/sessions/dto/reschedule-session.dto.ts
+++ b/backend/src/sessions/dto/reschedule-session.dto.ts
@@ -1,9 +1,16 @@
-import { IsDateString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsNotEmpty } from 'class-validator';
+import { IsAfterDate } from '../../common/validators';
 
 export class RescheduleSessionDto {
-  @IsDateString()
+  @ApiProperty({ description: 'New session start time (ISO 8601)', example: '2025-09-02T10:00:00Z' })
+  @IsDateString({}, { message: 'startTime must be a valid ISO 8601 date string' })
+  @IsNotEmpty()
   startTime: string;
 
-  @IsDateString()
+  @ApiProperty({ description: 'New session end time (ISO 8601), must be after startTime', example: '2025-09-02T11:00:00Z' })
+  @IsDateString({}, { message: 'endTime must be a valid ISO 8601 date string' })
+  @IsAfterDate('startTime', { message: 'endTime must be after startTime' })
+  @IsNotEmpty()
   endTime: string;
 }

--- a/backend/src/sessions/dto/session-history-query.dto.ts
+++ b/backend/src/sessions/dto/session-history-query.dto.ts
@@ -1,0 +1,15 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional } from 'class-validator';
+import { PaginationDto } from '../../common/dto';
+
+export class SessionHistoryQueryDto extends PaginationDto {
+  @ApiPropertyOptional({
+    description: 'Filter sessions by status',
+    enum: ['pending', 'confirmed', 'cancelled', 'completed', 'rescheduled'],
+  })
+  @IsOptional()
+  @IsIn(['pending', 'confirmed', 'cancelled', 'completed', 'rescheduled'], {
+    message: 'status must be one of: pending, confirmed, cancelled, completed, rescheduled',
+  })
+  status?: string;
+}

--- a/backend/src/sessions/sessions.controller.ts
+++ b/backend/src/sessions/sessions.controller.ts
@@ -16,6 +16,7 @@ import { CreateSessionDto } from './dto/create-session.dto';
 import { CancelSessionDto } from './dto/cancel-session.dto';
 import { RescheduleSessionDto } from './dto/reschedule-session.dto';
 import { RateSessionDto } from './dto/rate-session.dto';
+import { SessionHistoryQueryDto } from './dto/session-history-query.dto';
 
 @ApiTags('Sessions')
 @ApiBearerAuth()
@@ -62,8 +63,8 @@ export class SessionsController {
   }
 
   @Get()
-  getHistory(@Query('status') status: string | undefined, @Request() req: any) {
-    return this.sessionsService.getHistory(req.user.sub, status);
+  getHistory(@Query() query: SessionHistoryQueryDto, @Request() req: any) {
+    return this.sessionsService.getHistory(req.user.sub, query.status);
   }
 
   @Get(':id')

--- a/backend/src/users/dto/create-profile.dto.spec.ts
+++ b/backend/src/users/dto/create-profile.dto.spec.ts
@@ -1,0 +1,77 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateProfileDto } from './create-profile.dto';
+
+function make(overrides?: Partial<Record<string, unknown>>) {
+  return plainToInstance(CreateProfileDto, { profileType: 'mentor', ...overrides });
+}
+
+describe('CreateProfileDto', () => {
+  it('passes with minimal required fields (mentor)', async () => {
+    expect(await validate(make({ profileType: 'mentor' }))).toHaveLength(0);
+  });
+
+  it('passes with minimal required fields (mentee)', async () => {
+    expect(await validate(make({ profileType: 'mentee' }))).toHaveLength(0);
+  });
+
+  it('fails with an invalid profileType', async () => {
+    const errors = await validate(make({ profileType: 'superuser' }));
+    expect(errors.find((e) => e.property === 'profileType')).toBeDefined();
+  });
+
+  it('fails when bio exceeds 500 characters', async () => {
+    const errors = await validate(make({ bio: 'a'.repeat(501) }));
+    expect(errors.find((e) => e.property === 'bio')).toBeDefined();
+  });
+
+  it('passes with a bio of exactly 500 characters', async () => {
+    expect(await validate(make({ bio: 'a'.repeat(500) }))).toHaveLength(0);
+  });
+
+  it('fails when skills contains more than 20 items', async () => {
+    const errors = await validate(make({ skills: Array(21).fill('javascript') }));
+    expect(errors.find((e) => e.property === 'skills')).toBeDefined();
+  });
+
+  it('fails when hourlyRate is negative', async () => {
+    const errors = await validate(make({ hourlyRate: -10 }));
+    expect(errors.find((e) => e.property === 'hourlyRate')).toBeDefined();
+  });
+
+  it('passes with a valid hourlyRate', async () => {
+    expect(await validate(make({ hourlyRate: 75 }))).toHaveLength(0);
+  });
+
+  it('fails with an invalid timezone', async () => {
+    const errors = await validate(make({ timezone: 'Not/AReal' }));
+    expect(errors.find((e) => e.property === 'timezone')).toBeDefined();
+  });
+
+  it('passes with a valid timezone', async () => {
+    expect(await validate(make({ timezone: 'Europe/Berlin' }))).toHaveLength(0);
+  });
+
+  it('fails when availability slot has invalid day', async () => {
+    const errors = await validate(make({
+      availability: [{ day: 'funday', startTime: '09:00', endTime: '17:00' }],
+    }));
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('passes with valid nested availability slots', async () => {
+    const errors = await validate(make({
+      availability: [
+        { day: 'monday', startTime: '09:00', endTime: '12:00' },
+        { day: 'wednesday', startTime: '14:00', endTime: '18:00' },
+      ],
+    }));
+    expect(errors).toHaveLength(0);
+  });
+
+  it('fails when availability exceeds 14 slots', async () => {
+    const slots = Array(15).fill({ day: 'monday', startTime: '09:00', endTime: '10:00' });
+    const errors = await validate(make({ availability: slots }));
+    expect(errors.find((e) => e.property === 'availability')).toBeDefined();
+  });
+});

--- a/backend/src/users/dto/create-profile.dto.ts
+++ b/backend/src/users/dto/create-profile.dto.ts
@@ -1,0 +1,89 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { IsValidAvailabilitySlot, IsValidTimezone } from '../../common/validators';
+
+/** A single weekly availability slot */
+export class AvailabilitySlotDto {
+  @ApiProperty({ description: 'Day of the week', enum: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'] })
+  @IsString()
+  @IsNotEmpty()
+  day: string;
+
+  @ApiProperty({ description: 'Slot start time in HH:MM format', example: '09:00' })
+  @IsString()
+  @IsNotEmpty()
+  startTime: string;
+
+  @ApiProperty({ description: 'Slot end time in HH:MM format, must be after startTime', example: '17:00' })
+  @IsString()
+  @IsNotEmpty()
+  endTime: string;
+}
+
+export class CreateProfileDto {
+  @ApiProperty({ enum: ['mentor', 'mentee'], description: 'Type of profile to create' })
+  @IsEnum(['mentor', 'mentee'], { message: 'profileType must be mentor or mentee' })
+  profileType: 'mentor' | 'mentee';
+
+  @ApiPropertyOptional({ description: 'Short biography', maxLength: 500 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500, { message: 'bio must not exceed 500 characters' })
+  bio?: string;
+
+  @ApiPropertyOptional({ type: [String], description: 'List of skills (max 20)', maxItems: 20 })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true, message: 'each skill must be a string' })
+  @ArrayMaxSize(20, { message: 'skills must not contain more than 20 items' })
+  skills?: string[];
+
+  @ApiPropertyOptional({ description: 'Hourly rate in USD (mentors only)', minimum: 0 })
+  @IsOptional()
+  @IsNumber({}, { message: 'hourlyRate must be a number' })
+  @IsPositive({ message: 'hourlyRate must be a positive number' })
+  @Min(0)
+  hourlyRate?: number;
+
+  @ApiPropertyOptional({ type: [String], description: 'Learning goals (mentees only, max 10)' })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true, message: 'each learning goal must be a string' })
+  @ArrayMaxSize(10, { message: 'learningGoals must not contain more than 10 items' })
+  learningGoals?: string[];
+
+  @ApiPropertyOptional({ type: [String], description: 'Areas of interest (max 10)' })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true, message: 'each area of interest must be a string' })
+  @ArrayMaxSize(10, { message: 'areasOfInterest must not contain more than 10 items' })
+  areasOfInterest?: string[];
+
+  @ApiPropertyOptional({ description: 'IANA timezone identifier', example: 'America/New_York' })
+  @IsOptional()
+  @IsString()
+  @IsValidTimezone({ message: 'timezone must be a valid IANA timezone identifier' })
+  timezone?: string;
+
+  @ApiPropertyOptional({ type: [AvailabilitySlotDto], description: 'Weekly availability slots (max 14)' })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @ArrayMaxSize(14, { message: 'availability must not exceed 14 slots (2 per day)' })
+  @Type(() => AvailabilitySlotDto)
+  @IsValidAvailabilitySlot({ message: 'each availability slot must have a valid day, startTime, and endTime' })
+  availability?: AvailabilitySlotDto[];
+}

--- a/backend/src/users/dto/search-users.dto.ts
+++ b/backend/src/users/dto/search-users.dto.ts
@@ -1,37 +1,32 @@
-import { IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
-import { Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+import { PaginationDto } from '../../common/dto';
 
-export class SearchUsersDto {
+export class SearchUsersDto extends PaginationDto {
+  @ApiPropertyOptional({ enum: ['mentor', 'mentee', 'admin'], description: 'Filter by role' })
   @IsOptional()
-  @IsIn(['mentor', 'mentee', 'admin'])
+  @IsIn(['mentor', 'mentee', 'admin'], { message: 'role must be one of: mentor, mentee, admin' })
   role?: string;
 
+  @ApiPropertyOptional({ description: 'Search term (username, displayName)', maxLength: 100 })
   @IsOptional()
   @IsString()
+  @MaxLength(100, { message: 'search must not exceed 100 characters' })
   search?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by skill name', maxLength: 100 })
   @IsOptional()
   @IsString()
+  @MaxLength(100, { message: 'skill must not exceed 100 characters' })
   skill?: string;
 
+  @ApiPropertyOptional({ enum: ['name', 'createdAt', 'rating'], default: 'createdAt' })
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
-  @IsInt()
-  @Min(1)
-  page?: number = 1;
-
-  @IsOptional()
-  @Transform(({ value }) => parseInt(value))
-  @IsInt()
-  @Min(1)
-  @Max(100)
-  limit?: number = 20;
-
-  @IsOptional()
-  @IsIn(['name', 'createdAt', 'rating'])
+  @IsIn(['name', 'createdAt', 'rating'], { message: 'sortBy must be one of: name, createdAt, rating' })
   sortBy?: string = 'createdAt';
 
+  @ApiPropertyOptional({ enum: ['ASC', 'DESC'], default: 'DESC' })
   @IsOptional()
-  @IsIn(['ASC', 'DESC'])
+  @IsIn(['ASC', 'DESC'], { message: 'sortOrder must be ASC or DESC' })
   sortOrder?: 'ASC' | 'DESC' = 'DESC';
 }

--- a/backend/src/users/profile.controller.ts
+++ b/backend/src/users/profile.controller.ts
@@ -1,29 +1,7 @@
 import { Body, Controller, HttpCode, HttpStatus, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { IsEnum, IsOptional, IsString, IsNumber } from 'class-validator';
 import { JwtAuthGuard } from '../jwt-auth.guard';
-
-export class CreateProfileDto {
-  @IsEnum(['mentor', 'mentee'])
-  profileType: 'mentor' | 'mentee';
-
-  @IsOptional()
-  @IsString()
-  bio?: string;
-
-  @IsOptional()
-  skills?: string[];
-
-  @IsOptional()
-  @IsNumber()
-  hourlyRate?: number;
-
-  @IsOptional()
-  learningGoals?: string[];
-
-  @IsOptional()
-  areasOfInterest?: string[];
-}
+import { CreateProfileDto } from './dto/create-profile.dto';
 
 @ApiTags('users')
 @Controller('user')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "SkillSync_Server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
closes #723 
main.ts — added forbidNonWhitelisted: true and transformOptions: { enableImplicitConversion: true } to the global ValidationPipe
package.json — removed git merge conflict artifacts (feat/refresh-token / main lines) that made the JSON invalid
New custom validators (src/common/validators/)

IsStellarAddress — validates Stellar ED25519 public keys via stellar-sdk's StrKey.isValidEd25519PublicKey
IsAfterDate — cross-field date validator (e.g. endTime must be after startTime)
IsValidTimezone — validates IANA timezone strings using Intl.DateTimeFormat
IsValidAvailabilitySlot — validates { day, startTime (HH:MM), endTime (HH:MM) } slot objects
New base DTO (
pagination.dto.ts
)

Reusable PaginationDto with page and limit, used as a base class across SearchUsersDto, SessionHistoryQueryDto, GetNotificationsQueryDto, AdminUsersQueryDto
Strengthened existing DTOs

login.dto.ts
 — replaced bare @IsString() on wallet with @IsStellarAddress(), added @IsIn on network
create-session.dto.ts
 — added @IsAfterDate('startTime') on endTime, proper messages
reschedule-session.dto.ts
 — same @IsAfterDate treatment
cancel-session.dto.ts
 — added @MaxLength(500) with message
rate-session.dto.ts
 — added optional comment field with @MaxLength(1000)
New DTOs

session-history-query.dto.ts
 — typed query DTO for GET /sessions
create-profile.dto.ts
 — moved out of profile.controller.ts, added @IsValidTimezone, @IsValidAvailabilitySlot, @ArrayMaxSize, @ValidateNested on availability slots
get-notifications-query.dto.ts
 — typed query DTO for GET /notifications
admin-users-query.dto.ts
 — typed query DTO for GET /admin/users
Unit tests

is-stellar-address.validator.spec.ts
is-after-date.validator.spec.ts
is-valid-timezone.validator.spec.ts
is-valid-availability-slot.validator.spec.ts
pagination.dto.spec.ts
login.dto.spec.ts
create-session.dto.spec.ts
create-profile.dto.spec.ts