### PR TITLE
feat: logout and token invalidation (#692)

### DIFF
--- a/backend/src/auth.controller.spec.ts
+++ b/backend/src/auth.controller.spec.ts
@@ -8,6 +8,9 @@ const validStellarAddress = Keypair.random().publicKey();
 describe('AuthController', () => {
   let controller: AuthController;
   let redisService: jest.Mocked<Pick<RedisService, 'set' | 'get' | 'del' | 'getClient'>>;
+  let authService: { blacklistToken: jest.Mock; incrementTokenVersion: jest.Mock };
+  let refreshTokenService: { revokeAllUserTokens: jest.Mock };
+  let auditLogService: { logEvent: jest.Mock; logAttempt: jest.Mock };
 
   beforeEach(() => {
     redisService = {
@@ -16,14 +19,27 @@ describe('AuthController', () => {
       del: jest.fn(),
       getClient: jest.fn(),
     };
+    authService = {
+      blacklistToken: jest.fn().mockResolvedValue(undefined),
+      incrementTokenVersion: jest.fn().mockResolvedValue(1),
+    };
+    refreshTokenService = {
+      revokeAllUserTokens: jest.fn().mockResolvedValue(undefined),
+    };
+    auditLogService = {
+      logEvent: jest.fn().mockResolvedValue(undefined),
+      logAttempt: jest.fn().mockResolvedValue(undefined),
+    };
 
     controller = new AuthController(
       redisService as unknown as RedisService,
-      undefined as any, // authService
+      authService as any,
       undefined as any, // userService
       undefined as any, // loginAttemptService
-      undefined as any, // auditLogService
-      undefined as any, // refreshTokenService
+      auditLogService as any,
+      undefined as any, // suspiciousLoginService
+      refreshTokenService as any,
+      undefined as any, // suspiciousActivityService
     );
   });
 
@@ -56,5 +72,54 @@ describe('AuthController', () => {
       300,
       'nonce',
     );
+  });
+
+  describe('logout', () => {
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const mockReq = {
+      user: { sub: 'user-1', jti: 'jti-abc', exp, wallet: 'G123', roles: [], permissions: [], ver: 0 },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'jest' },
+    };
+
+    it('blacklists jti with remaining TTL and revokes refresh tokens', async () => {
+      const result = await controller.logout(mockReq as any);
+
+      expect(authService.blacklistToken).toHaveBeenCalledWith('jti-abc', expect.any(Number));
+      const ttlArg = (authService.blacklistToken as jest.Mock).mock.calls[0][1];
+      expect(ttlArg).toBeGreaterThan(0);
+      expect(ttlArg).toBeLessThanOrEqual(600);
+
+      expect(refreshTokenService.revokeAllUserTokens).toHaveBeenCalledWith('user-1');
+      expect(auditLogService.logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-1', details: expect.objectContaining({ action: 'logout' }) }),
+      );
+      expect(result).toEqual({ message: 'Logged out successfully' });
+    });
+
+    it('uses fallback TTL of 900 when exp missing', async () => {
+      const req = { ...mockReq, user: { ...mockReq.user, exp: undefined } };
+      await controller.logout(req as any);
+      expect(authService.blacklistToken).toHaveBeenCalledWith('jti-abc', 900);
+    });
+  });
+
+  describe('logoutAll', () => {
+    const mockReq = {
+      user: { sub: 'user-1', jti: 'jti-abc', exp: Math.floor(Date.now() / 1000) + 600, wallet: 'G123', roles: [], permissions: [], ver: 0 },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'jest' },
+    };
+
+    it('increments token version and revokes all refresh tokens', async () => {
+      const result = await controller.logoutAll(mockReq as any);
+
+      expect(authService.incrementTokenVersion).toHaveBeenCalledWith('user-1');
+      expect(refreshTokenService.revokeAllUserTokens).toHaveBeenCalledWith('user-1');
+      expect(auditLogService.logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-1', details: expect.objectContaining({ action: 'logout_all' }) }),
+      );
+      expect(result).toEqual({ message: 'All sessions invalidated' });
+    });
   });
 });

--- a/backend/src/auth.controller.ts
+++ b/backend/src/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpException, HttpStatus, Param, Post, Req } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, HttpStatus, Param, Post, Req, UseGuards } from '@nestjs/common';
 import {
   ApiBody,
   ApiOperation,
@@ -21,6 +21,9 @@ import { AuditLogService } from './auth/audit-log.service';
 import { SuspiciousLoginService } from './auth/suspicious-login.service';
 import { RefreshTokenService } from './refresh-token/refresh-token.service';
 import { SuspiciousActivityService } from './auth/suspicious-activity.service';
+import { JwtAuthGuard } from './jwt-auth.guard';
+import { AuditEventType } from './auth/entities/audit-log.entity';
+import { JwtAccessTokenPayload } from './jwt-payload.interface';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -241,6 +244,61 @@ export class AuthController {
       }
       throw new HttpException(error.message || 'Failed to refresh token', HttpStatus.UNAUTHORIZED);
     }
+  }
+
+  @Post('logout')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Logout and invalidate current access token' })
+  @ApiResponse({ status: 200, description: 'Logged out successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async logout(@Req() req: any) {
+    const user: JwtAccessTokenPayload = req.user;
+    const ip = req.ip || req.connection?.remoteAddress || 'unknown';
+
+    const now = Math.floor(Date.now() / 1000);
+    const ttl = user.exp ? Math.max(user.exp - now, 1) : 900;
+
+    await this.authService.blacklistToken(user.jti, ttl);
+    await this.refreshTokenService.revokeAllUserTokens(user.sub);
+
+    await this.auditLogService.logEvent({
+      userId: user.sub,
+      eventType: AuditEventType.TOKEN_INVALIDATED,
+      audit: {
+        ipAddress: ip,
+        userAgent: req.headers['user-agent'] || '',
+        deviceFingerprint: null,
+      },
+      details: { jti: user.jti, action: 'logout' },
+    });
+
+    return { message: 'Logged out successfully' };
+  }
+
+  @Post('logout-all')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Logout all sessions by invalidating token version' })
+  @ApiResponse({ status: 200, description: 'All sessions invalidated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async logoutAll(@Req() req: any) {
+    const user: JwtAccessTokenPayload = req.user;
+    const ip = req.ip || req.connection?.remoteAddress || 'unknown';
+
+    await this.authService.incrementTokenVersion(user.sub);
+    await this.refreshTokenService.revokeAllUserTokens(user.sub);
+
+    await this.auditLogService.logEvent({
+      userId: user.sub,
+      eventType: AuditEventType.TOKEN_INVALIDATED,
+      audit: {
+        ipAddress: ip,
+        userAgent: req.headers['user-agent'] || '',
+        deviceFingerprint: null,
+      },
+      details: { action: 'logout_all' },
+    });
+
+    return { message: 'All sessions invalidated' };
   }
 
   private deleteNonce(wallet: string) {

--- a/backend/src/auth.module.ts
+++ b/backend/src/auth.module.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
+import { JwtAuthGuard } from './jwt-auth.guard';
 import { RedisModule } from './redis/redis.module';
 import { User } from './entities/user.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
@@ -48,6 +49,7 @@ import { UserEncryptionSubscriber } from './common/encryption/user-encryption.su
   providers: [
     AuthService,
     JwtStrategy,
+    JwtAuthGuard,
     UserService,
     LoginAttemptService,
     AuditLogService,
@@ -55,6 +57,6 @@ import { UserEncryptionSubscriber } from './common/encryption/user-encryption.su
     RefreshTokenService,
     UserEncryptionSubscriber,
   ],
-  exports: [AuthService, RefreshTokenService, SuspiciousLoginService],
+  exports: [AuthService, JwtAuthGuard, RefreshTokenService, SuspiciousLoginService],
 })
 export class AuthModule {}

--- a/backend/src/auth.service.ts
+++ b/backend/src/auth.service.ts
@@ -91,6 +91,10 @@ export class AuthService {
     return true;
   }
 
+  async blacklistToken(jti: string, ttlSeconds: number): Promise<void> {
+    await this.redisService.getClient().set(`blacklist:jti:${jti}`, '1', 'EX', ttlSeconds);
+  }
+
   async decodeToken(token: string): Promise<any> {
     try {
       return this.jwtService.decode(token);

--- a/backend/src/jwt-auth.guard.spec.ts
+++ b/backend/src/jwt-auth.guard.spec.ts
@@ -4,10 +4,12 @@ import { JwtAuthGuard } from './jwt-auth.guard';
 const mockVerifyAsync = jest.fn();
 const mockRedisGet = jest.fn();
 const mockReflector = { getAllAndOverride: jest.fn() };
+const mockValidateTokenVersion = jest.fn();
 
 const mockJwtService = { verifyAsync: mockVerifyAsync };
 const mockConfig = { get: jest.fn((key: string) => key === 'JWT_SECRET' ? 'test-secret' : undefined) };
 const mockRedis = { getClient: jest.fn(() => ({ get: mockRedisGet })) };
+const mockAuthService = { validateTokenVersion: mockValidateTokenVersion };
 
 const validPayload = { sub: 'user-1', wallet: 'G123', roles: [], permissions: [], jti: 'jti-abc', ver: 0 };
 
@@ -27,11 +29,13 @@ describe('JwtAuthGuard', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockValidateTokenVersion.mockResolvedValue(true);
     guard = new JwtAuthGuard(
       mockJwtService as any,
       mockConfig as any,
       mockRedis as any,
       mockReflector as any,
+      mockAuthService as any,
     );
   });
 
@@ -115,6 +119,26 @@ describe('JwtAuthGuard', () => {
       const ctx = makeContext('Bearer blacklisted.token', true);
       expect(await guard.canActivate(ctx as any)).toBe(true);
     });
+  });
+
+  it('throws 401 token_invalidated when token version is stale', async () => {
+    mockVerifyAsync.mockResolvedValue(validPayload);
+    mockRedisGet.mockResolvedValue(null);
+    mockValidateTokenVersion.mockResolvedValue(false);
+
+    const ctx = makeContext('Bearer valid.token.here');
+    await expect(guard.canActivate(ctx as any)).rejects.toMatchObject({
+      response: { code: 'token_invalidated' },
+    });
+  });
+
+  it('returns true (not throws) for stale version in optional mode', async () => {
+    mockVerifyAsync.mockResolvedValue(validPayload);
+    mockRedisGet.mockResolvedValue(null);
+    mockValidateTokenVersion.mockResolvedValue(false);
+
+    const ctx = makeContext('Bearer valid.token', true);
+    expect(await guard.canActivate(ctx as any)).toBe(true);
   });
 
   it('verifies token in under 5ms average', async () => {

--- a/backend/src/jwt-auth.guard.ts
+++ b/backend/src/jwt-auth.guard.ts
@@ -11,6 +11,7 @@ import { ConfigService } from '@nestjs/config';
 import type { Request } from 'express';
 import { RedisService } from './redis/redis.service';
 import { JwtAccessTokenPayload } from './jwt-payload.interface';
+import { AuthService } from './auth.service';
 
 export const OPTIONAL_AUTH_KEY = 'optionalAuth';
 /** Mark a route as accepting requests with or without a valid token. */
@@ -23,6 +24,7 @@ export class JwtAuthGuard implements CanActivate {
     private readonly configService: ConfigService,
     private readonly redisService: RedisService,
     private readonly reflector: Reflector,
+    private readonly authService: AuthService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -62,6 +64,13 @@ export class JwtAuthGuard implements CanActivate {
     if (blacklisted) {
       if (optional) return true;
       throw new UnauthorizedException({ message: 'Token has been revoked', code: 'token_revoked' });
+    }
+
+    // Token version check (invalidated by logoutAll / revokeAll)
+    const versionValid = await this.authService.validateTokenVersion(payload);
+    if (!versionValid) {
+      if (optional) return true;
+      throw new UnauthorizedException({ message: 'Token version invalidated', code: 'token_invalidated' });
     }
 
     req.user = payload;


### PR DESCRIPTION
## Summary

- `POST /auth/logout`: blacklists the current access token JTI in Redis (TTL = remaining token lifetime), revokes all DB refresh tokens for the user, logs a `TOKEN_INVALIDATED` audit event with IP
- `POST /auth/logout-all`: increments token version (invalidates all existing access tokens), revokes all DB refresh tokens, logs audit event
- `AuthService.blacklistToken(jti, ttlSeconds)`: writes `blacklist:jti:<jti> = 1` to Redis with EX TTL
- `JwtAuthGuard`: added token version check via `authService.validateTokenVersion()` so `logoutAll` immediately rejects stale-version tokens on every subsequent request
- `auth.module.ts`: registers and exports `JwtAuthGuard` so `@UseGuards(JwtAuthGuard)` resolves via DI

## Changes

- `backend/src/auth.service.ts` — `blacklistToken` method
- `backend/src/jwt-auth.guard.ts` — `AuthService` dependency + version check after blacklist check
- `backend/src/auth.controller.ts` — `logout` and `logoutAll` endpoints with `@UseGuards(JwtAuthGuard)`
- `backend/src/auth.module.ts` — `JwtAuthGuard` added to providers + exports
- `backend/src/auth.controller.spec.ts` — tests for `logout` (blacklist TTL, fallback TTL, audit log) and `logoutAll` (version bump, revoke, audit log)
- `backend/src/jwt-auth.guard.spec.ts` — tests for stale-version rejection in normal and optional mode

## Verification

- `POST /auth/logout` with a Bearer token → blacklists JTI in Redis, revokes refresh tokens, returns `{ message: "Logged out successfully" }`
- Subsequent request with same token → 401 `token_revoked`
- `POST /auth/logout-all` → increments token version, revokes all refresh tokens; any existing token with old `ver` → 401 `token_invalidated`
- Tests: 16/18 pass; 2 pre-existing failures (`enforceRateLimit not a function` in `getNonce` — unrelated to this PR)

closes #692