### PR TITLE
feat: auth module structure — strategies, nonce DTO, tests folder (#687)

### DIFF
--- a/backend/src/auth/dto/nonce.dto.ts
+++ b/backend/src/auth/dto/nonce.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn } from 'class-validator';
+import { IsStellarAddress } from '../../common/validators';
+
+export class NonceRequestDto {
+  @ApiProperty({
+    example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    description: 'Stellar ED25519 public key (56 chars, starts with G)',
+  })
+  @IsStellarAddress()
+  walletAddress: string;
+
+  @ApiProperty({
+    example: 'testnet',
+    enum: ['mainnet', 'testnet'],
+    description: 'Stellar network identifier',
+  })
+  @IsIn(['mainnet', 'testnet'], { message: 'network must be one of: mainnet, testnet' })
+  network: string;
+}
+
+export class NonceResponseDto {
+  @ApiProperty({ example: 'a3f8c2...', description: '64-char hex nonce to sign' })
+  nonce: string;
+
+  @ApiProperty({
+    example: '2024-01-01T00:05:00.000Z',
+    description: 'ISO-8601 timestamp after which the nonce is no longer valid',
+  })
+  expiresAt: string;
+}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,43 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { AuthService } from '../../auth.service';
+import { JwtAccessTokenPayload } from '../../jwt-payload.interface';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly authService: AuthService,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: JwtStrategy.resolveSecret(configService),
+      algorithms: [configService.get<string>('JWT_ALGORITHM') || 'HS256'],
+    });
+  }
+
+  private static resolveSecret(config: ConfigService): string {
+    const algorithm =
+      config.get('JWT_ALGORITHM') || (config.get('JWT_PRIVATE_KEY') ? 'RS256' : 'HS256');
+    if (algorithm === 'RS256') {
+      const pub = config.get<string>('JWT_PUBLIC_KEY');
+      if (!pub) throw new Error('JWT_PUBLIC_KEY is required for RS256 verification');
+      return pub;
+    }
+    const secret = config.get<string>('JWT_SECRET');
+    if (!secret) throw new Error('JWT_SECRET is required for HS256 verification');
+    return secret;
+  }
+
+  async validate(payload: JwtAccessTokenPayload): Promise<JwtAccessTokenPayload> {
+    if (!payload.sub || !payload.wallet || !payload.jti) {
+      throw new UnauthorizedException('Invalid token payload');
+    }
+    const valid = await this.authService.validateTokenVersion(payload);
+    if (!valid) throw new UnauthorizedException('Token version invalidated');
+    return payload;
+  }
+}

--- a/backend/src/auth/strategies/wallet.strategy.ts
+++ b/backend/src/auth/strategies/wallet.strategy.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+import passport from 'passport';
+import { Keypair } from 'stellar-sdk';
+import type { Request } from 'express';
+import { RedisService } from '../../redis/redis.service';
+import { UserService } from '../user.service';
+
+export interface WalletAuthRequest {
+  wallet: string;
+  signature: string;
+  nonce: string;
+  network: 'mainnet' | 'testnet';
+}
+
+/**
+ * Custom Passport strategy for Stellar wallet authentication.
+ *
+ * Flow: client supplies wallet + nonce + ed25519 signature → strategy verifies
+ * the signature against the nonce stored in Redis and resolves the User entity.
+ *
+ * Register with AuthGuard('wallet') after adding WalletStrategy to providers.
+ */
+@Injectable()
+export class WalletStrategy {
+  readonly name = 'wallet';
+
+  // Injected by the Passport framework at authentication time
+  declare success: (user: any, info?: any) => void;
+  declare fail: (challenge: any, status?: number) => void;
+  declare error: (err: Error) => void;
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly userService: UserService,
+  ) {
+    passport.use(this.name, this as any);
+  }
+
+  async authenticate(req: Request, _options?: unknown): Promise<void> {
+    const { wallet, signature, nonce, network } = (req.body ?? {}) as WalletAuthRequest;
+
+    if (!wallet || !signature || !nonce || !network) {
+      return this.fail(
+        { message: 'wallet, signature, nonce, and network are required' },
+        400,
+      );
+    }
+
+    try {
+      const storedNonce = await this.redisService.get(wallet, 'nonce');
+      if (!storedNonce || storedNonce !== nonce) {
+        return this.fail({ message: 'Nonce expired or invalid' }, 401);
+      }
+
+      if (!this.verifySignature(wallet, signature, nonce, network)) {
+        return this.fail({ message: 'Invalid wallet signature' }, 401);
+      }
+
+      const user = await this.userService.findOrCreateByWallet(wallet);
+      this.success(user);
+    } catch (err) {
+      this.error(err as Error);
+    }
+  }
+
+  private verifySignature(
+    wallet: string,
+    signature: string,
+    nonce: string,
+    network: string,
+  ): boolean {
+    try {
+      const message = Buffer.from(`${network}:${nonce}`, 'utf8');
+      const keypair = Keypair.fromPublicKey(wallet);
+      return keypair.verify(message, Buffer.from(signature, 'base64'));
+    } catch {
+      return false;
+    }
+  }
+}

--- a/backend/src/auth/tests/auth.e2e.spec.ts
+++ b/backend/src/auth/tests/auth.e2e.spec.ts
@@ -1,0 +1,97 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule } from '@nestjs/config';
+import * as request from 'supertest';
+import { AuthController } from '../../auth.controller';
+import { AuthService } from '../../auth.service';
+import { RedisService } from '../../redis/redis.service';
+import { AuditLogService } from '../audit-log.service';
+
+const JWT_SECRET = 'e2e-test-secret';
+
+const mockRedis = {
+  set: jest.fn(),
+  get: jest.fn(),
+  del: jest.fn(),
+  getClient: jest.fn(() => ({ get: jest.fn().mockResolvedValue(null), incr: jest.fn(), set: jest.fn() })),
+};
+const mockAudit = { logAttempt: jest.fn(), logEvent: jest.fn() };
+const mockUserSvc = { findOrCreateByWallet: jest.fn() };
+const mockLoginAttempt = { incrementAttempts: jest.fn(), resetAttempts: jest.fn() };
+const mockSuspiciousLogin = {
+  recordFailedAttempt: jest.fn(),
+  checkSuspicious: jest.fn(),
+  recordSuccessfulLogin: jest.fn(),
+};
+const mockSuspiciousActivity = { isLockedDown: jest.fn().mockResolvedValue(false), trackFailedAttempt: jest.fn(), lockdownTtl: jest.fn() };
+const mockRefreshToken = {
+  createRefreshToken: jest.fn(),
+  validateRefreshToken: jest.fn(),
+  rotateRefreshToken: jest.fn(),
+  revokeAllUserTokens: jest.fn(),
+};
+const mockThrottler = { canActivate: jest.fn().mockReturnValue(true) };
+
+describe('Auth endpoints (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        JwtModule.register({ secret: JWT_SECRET, signOptions: { expiresIn: '15m' } }),
+      ],
+      controllers: [AuthController],
+      providers: [
+        AuthService,
+        { provide: RedisService, useValue: mockRedis },
+        { provide: AuditLogService, useValue: mockAudit },
+        { provide: 'UserService', useValue: mockUserSvc },
+        { provide: 'LoginAttemptService', useValue: mockLoginAttempt },
+        { provide: 'SuspiciousLoginService', useValue: mockSuspiciousLogin },
+        { provide: 'SuspiciousActivityService', useValue: mockSuspiciousActivity },
+        { provide: 'RefreshTokenService', useValue: mockRefreshToken },
+      ],
+    })
+      .overrideGuard('ThrottlerGuard')
+      .useValue(mockThrottler)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('GET /auth/nonce/:walletAddress', () => {
+    it('400 for invalid wallet address', async () => {
+      await request(app.getHttpServer())
+        .get('/auth/nonce/not-a-valid-key')
+        .expect(400);
+    });
+  });
+
+  describe('POST /auth/login', () => {
+    it('400 for missing body fields', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({})
+        .expect(400);
+    });
+  });
+
+  describe('POST /auth/refresh', () => {
+    it('400 when refreshToken is absent', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/refresh')
+        .send({})
+        .expect(400);
+    });
+  });
+});

--- a/backend/src/auth/tests/jwt.strategy.spec.ts
+++ b/backend/src/auth/tests/jwt.strategy.spec.ts
@@ -1,0 +1,69 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { JwtStrategy } from '../strategies/jwt.strategy';
+import { JwtAccessTokenPayload } from '../../jwt-payload.interface';
+
+const validPayload: JwtAccessTokenPayload = {
+  sub: 'user-1',
+  wallet: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  roles: [],
+  permissions: [],
+  jti: 'jti-abc',
+  ver: 1,
+  iat: Math.floor(Date.now() / 1000) - 60,
+};
+
+const mockValidateTokenVersion = jest.fn();
+const mockAuthService = { validateTokenVersion: mockValidateTokenVersion };
+
+const mockConfig = {
+  get: jest.fn((key: string) => {
+    if (key === 'JWT_SECRET') return 'test-secret';
+    if (key === 'JWT_ALGORITHM') return 'HS256';
+    return undefined;
+  }),
+};
+
+function makeStrategy(): JwtStrategy {
+  return new JwtStrategy(mockConfig as any, mockAuthService as any);
+}
+
+describe('JwtStrategy', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns payload when token version is current', async () => {
+    mockValidateTokenVersion.mockResolvedValue(true);
+    const strategy = makeStrategy();
+    const result = await strategy.validate(validPayload);
+    expect(result).toEqual(validPayload);
+    expect(mockValidateTokenVersion).toHaveBeenCalledWith(validPayload);
+  });
+
+  it('throws 401 when token version is stale', async () => {
+    mockValidateTokenVersion.mockResolvedValue(false);
+    const strategy = makeStrategy();
+    await expect(strategy.validate(validPayload)).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('throws 401 when sub is missing', async () => {
+    mockValidateTokenVersion.mockResolvedValue(true);
+    const strategy = makeStrategy();
+    const bad = { ...validPayload, sub: '' };
+    await expect(strategy.validate(bad)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('throws 401 when wallet is missing', async () => {
+    mockValidateTokenVersion.mockResolvedValue(true);
+    const strategy = makeStrategy();
+    const bad = { ...validPayload, wallet: '' };
+    await expect(strategy.validate(bad)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('throws 401 when jti is missing', async () => {
+    mockValidateTokenVersion.mockResolvedValue(true);
+    const strategy = makeStrategy();
+    const bad = { ...validPayload, jti: '' };
+    await expect(strategy.validate(bad)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+});

--- a/backend/src/auth/tests/wallet.strategy.spec.ts
+++ b/backend/src/auth/tests/wallet.strategy.spec.ts
@@ -1,0 +1,130 @@
+import { Keypair } from 'stellar-sdk';
+import { WalletStrategy } from '../strategies/wallet.strategy';
+
+const keypair = Keypair.random();
+const wallet = keypair.publicKey();
+
+function makeSignature(nonce: string, network: string): string {
+  const message = Buffer.from(`${network}:${nonce}`, 'utf8');
+  return keypair.sign(message).toString('base64');
+}
+
+const mockUser = { id: 'user-1', wallet };
+const mockRedisGet = jest.fn();
+const mockFindOrCreate = jest.fn().mockResolvedValue(mockUser);
+
+const mockRedisService = { get: mockRedisGet };
+const mockUserService = { findOrCreateByWallet: mockFindOrCreate };
+
+function makeStrategy(): WalletStrategy {
+  return new WalletStrategy(mockRedisService as any, mockUserService as any);
+}
+
+function makeRequest(body: Record<string, string>) {
+  return { body } as any;
+}
+
+describe('WalletStrategy', () => {
+  let strategy: WalletStrategy;
+  let successSpy: jest.Mock;
+  let failSpy: jest.Mock;
+  let errorSpy: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    strategy = makeStrategy();
+    successSpy = jest.fn();
+    failSpy = jest.fn();
+    errorSpy = jest.fn();
+    (strategy as any).success = successSpy;
+    (strategy as any).fail = failSpy;
+    (strategy as any).error = errorSpy;
+  });
+
+  it('calls success with user on valid signature', async () => {
+    const nonce = 'abc123nonce';
+    mockRedisGet.mockResolvedValue(nonce);
+
+    await strategy.authenticate(
+      makeRequest({
+        wallet,
+        signature: makeSignature(nonce, 'testnet'),
+        nonce,
+        network: 'testnet',
+      }),
+    );
+
+    expect(mockRedisGet).toHaveBeenCalledWith(wallet, 'nonce');
+    expect(mockFindOrCreate).toHaveBeenCalledWith(wallet);
+    expect(successSpy).toHaveBeenCalledWith(mockUser);
+    expect(failSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails with 400 when required fields are missing', async () => {
+    await strategy.authenticate(makeRequest({ wallet }));
+
+    expect(failSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('required') }),
+      400,
+    );
+    expect(successSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails with 401 when stored nonce does not match', async () => {
+    mockRedisGet.mockResolvedValue('different-nonce');
+
+    await strategy.authenticate(
+      makeRequest({ wallet, signature: 'sig', nonce: 'my-nonce', network: 'testnet' }),
+    );
+
+    expect(failSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Nonce expired or invalid' }),
+      401,
+    );
+  });
+
+  it('fails with 401 when nonce not found in Redis', async () => {
+    mockRedisGet.mockResolvedValue(null);
+
+    await strategy.authenticate(
+      makeRequest({ wallet, signature: 'sig', nonce: 'nonce', network: 'testnet' }),
+    );
+
+    expect(failSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Nonce expired or invalid' }),
+      401,
+    );
+  });
+
+  it('fails with 401 when signature is invalid', async () => {
+    const nonce = 'abc123';
+    mockRedisGet.mockResolvedValue(nonce);
+
+    await strategy.authenticate(
+      makeRequest({ wallet, signature: 'badsignature==', nonce, network: 'testnet' }),
+    );
+
+    expect(failSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Invalid wallet signature' }),
+      401,
+    );
+    expect(successSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls error when an unexpected exception occurs', async () => {
+    const nonce = 'abc123';
+    mockRedisGet.mockResolvedValue(nonce);
+    mockFindOrCreate.mockRejectedValue(new Error('DB down'));
+
+    await strategy.authenticate(
+      makeRequest({
+        wallet,
+        signature: makeSignature(nonce, 'testnet'),
+        nonce,
+        network: 'testnet',
+      }),
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.any(Error));
+  });
+});


### PR DESCRIPTION
## Summary

Completes the missing pieces from the auth module scaffold acceptance criteria:

- **`auth/dto/nonce.dto.ts`** — `NonceRequestDto` (walletAddress + network, validated) and `NonceResponseDto` (nonce + expiresAt)
- **`auth/strategies/jwt.strategy.ts`** — Passport JWT strategy; validates token version via `AuthService.validateTokenVersion()`. Canonical location for the strategy inside the auth module folder
- **`auth/strategies/wallet.strategy.ts`** — Custom Passport strategy for Stellar wallet auth; verifies ed25519 signature against Redis-stored nonce, resolves User via `UserService`, registers with `passport.use()` so `AuthGuard('wallet')` works
- **`auth/tests/`** — tests folder with:
  - `jwt.strategy.spec.ts` — 5 unit tests (valid payload, stale version, missing sub/wallet/jti)
  - `wallet.strategy.spec.ts` — 6 unit tests (success, missing fields, nonce mismatch, invalid sig, unexpected error)
  - `auth.e2e.spec.ts` — e2e scaffold covering nonce, login, and refresh endpoints with a real NestJS testing app

## What already existed (not duplicated)

`src/jwt.strategy.ts` at the root is left untouched — the new `auth/strategies/jwt.strategy.ts` is the canonical location added by this PR. `auth/guards/` and `auth/auth.module.ts` are also unchanged.

## Verification

```
Tests: 11 passed, 11 total (jwt.strategy.spec + wallet.strategy.spec)
```

closes #687