### PR TITLE
Complete User module: account CRUD, email field, admin listing

### DIFF
--- a/backend/src/database/migrations/1722000000000-AddEmailToUsers.ts
+++ b/backend/src/database/migrations/1722000000000-AddEmailToUsers.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEmailToUsers1722000000000 implements MigrationInterface {
+  name = 'AddEmailToUsers1722000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users" ADD COLUMN "email" varchar(255)
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "UQ_users_email" ON "users" ("email") WHERE "email" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "UQ_users_email"`);
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN IF EXISTS "email"`,
+    );
+  }
+}

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,0 +1,18 @@
+import { IsEmail, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateUserDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  username?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(150)
+  displayName?: string;
+
+  @IsOptional()
+  @IsEmail()
+  @MaxLength(255)
+  email?: string;
+}

--- a/backend/src/users/dto/user-query.dto.ts
+++ b/backend/src/users/dto/user-query.dto.ts
@@ -1,0 +1,22 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { UserStatus } from '../enums/user-status.enum.js';
+
+export class UserQueryDto {
+  @IsOptional()
+  @IsEnum(UserStatus)
+  status?: UserStatus;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/backend/src/users/dto/user-response.dto.ts
+++ b/backend/src/users/dto/user-response.dto.ts
@@ -1,0 +1,29 @@
+import { User } from '../entities/user.entity.js';
+import { UserStatus } from '../enums/user-status.enum.js';
+import { AuthRole } from '../../common/enums/auth-role.enum.js';
+
+export class UserResponseDto {
+  id: string;
+  walletAddress: string;
+  username: string | null;
+  displayName: string | null;
+  email: string | null;
+  status: UserStatus;
+  roles: AuthRole[];
+  createdAt: Date;
+  updatedAt: Date;
+
+  static fromEntity(user: User): UserResponseDto {
+    const dto = new UserResponseDto();
+    dto.id = user.id;
+    dto.walletAddress = user.walletAddress;
+    dto.username = user.username ?? null;
+    dto.displayName = user.displayName ?? null;
+    dto.email = user.email ?? null;
+    dto.status = user.status;
+    dto.roles = (user.roles ?? []).map((role) => role.name);
+    dto.createdAt = user.createdAt;
+    dto.updatedAt = user.updatedAt;
+    return dto;
+  }
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -23,6 +23,9 @@ export class User {
   @Column({ type: 'varchar', nullable: true })
   username: string;
 
+  @Column({ type: 'varchar', length: 255, nullable: true, unique: true })
+  email: string;
+
   @Column({ type: 'varchar', nullable: true })
   displayName: string;
 

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -2,12 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller.js';
 import { UsersService } from './users.service.js';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard.js';
+import { RolesGuard } from '../auth/guards/roles.guard.js';
 import { ThrottlerGuard } from '@nestjs/throttler';
+import { UserStatus } from './enums/user-status.enum.js';
+import { AuthRole } from '../common/enums/auth-role.enum.js';
 
 describe('UsersController', () => {
   let controller: UsersController;
 
   const mockUsersService = {
+    findById: jest.fn(),
+    updateUser: jest.fn(),
+    deactivateUser: jest.fn(),
+    findAll: jest.fn(),
     createMentorProfile: jest.fn(),
     createMenteeProfile: jest.fn(),
     updateMentorProfile: jest.fn(),
@@ -34,6 +41,8 @@ describe('UsersController', () => {
     })
       .overrideGuard(JwtAuthGuard)
       .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
       .overrideGuard(ThrottlerGuard)
       .useValue({ canActivate: () => true })
       .compile();
@@ -43,6 +52,87 @@ describe('UsersController', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  const mockUserEntity = {
+    id: 'user-1',
+    walletAddress: 'test-wallet',
+    username: 'skillsync-user',
+    displayName: 'Skillsync User',
+    email: 'user@example.com',
+    status: UserStatus.ACTIVE,
+    roles: [{ name: AuthRole.MENTOR }],
+    tokenVersion: 0,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-02'),
+  };
+
+  describe('getMe', () => {
+    it('should return the requesting user', async () => {
+      mockUsersService.findById.mockResolvedValue(mockUserEntity);
+
+      const result = await controller.getMe(mockRequest('user-1') as any);
+
+      expect(mockUsersService.findById).toHaveBeenCalledWith('user-1');
+      expect(result).toMatchObject({
+        id: 'user-1',
+        walletAddress: 'test-wallet',
+        email: 'user@example.com',
+        roles: [AuthRole.MENTOR],
+      });
+    });
+  });
+
+  describe('updateMe', () => {
+    it('should update and return the requesting user', async () => {
+      const dto = { displayName: 'New Name' };
+      mockUsersService.updateUser.mockResolvedValue({
+        ...mockUserEntity,
+        displayName: 'New Name',
+      });
+
+      const result = await controller.updateMe(
+        dto,
+        mockRequest('user-1') as any,
+      );
+
+      expect(mockUsersService.updateUser).toHaveBeenCalledWith('user-1', dto);
+      expect(result.displayName).toBe('New Name');
+    });
+  });
+
+  describe('deleteMe', () => {
+    it('should deactivate the requesting user', async () => {
+      mockUsersService.deactivateUser.mockResolvedValue({
+        ...mockUserEntity,
+        status: UserStatus.DELETED,
+      });
+
+      const result = await controller.deleteMe(mockRequest('user-1') as any);
+
+      expect(mockUsersService.deactivateUser).toHaveBeenCalledWith('user-1');
+      expect(result.status).toBe(UserStatus.DELETED);
+    });
+  });
+
+  describe('listUsers', () => {
+    it('should return a paginated, mapped list of users', async () => {
+      mockUsersService.findAll.mockResolvedValue({
+        data: [mockUserEntity],
+        total: 1,
+        page: 1,
+        limit: 20,
+      });
+
+      const result = await controller.listUsers({ page: 1, limit: 20 });
+
+      expect(mockUsersService.findAll).toHaveBeenCalledWith({
+        page: 1,
+        limit: 20,
+      });
+      expect(result.total).toBe(1);
+      expect(result.data[0]).toMatchObject({ id: 'user-1' });
+    });
   });
 
   describe('createProfile', () => {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,12 +1,14 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -15,15 +17,58 @@ import { UsersService } from './users.service.js';
 import { CreateProfileDto } from './dto/create-profile.dto.js';
 import { UpdateMentorProfileDto } from './dto/update-mentor-profile.dto.js';
 import { UpdateMenteeProfileDto } from './dto/update-mentee-profile.dto.js';
+import { UpdateUserDto } from './dto/update-user.dto.js';
+import { UserQueryDto } from './dto/user-query.dto.js';
+import { UserResponseDto } from './dto/user-response.dto.js';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard.js';
+import { RolesGuard } from '../auth/guards/roles.guard.js';
+import { Roles } from '../auth/decorators/roles.decorator.js';
 import { JwtAccessTokenPayload } from '../auth/interfaces/jwt-payload.interface.js';
+import { AuthRole } from '../common/enums/auth-role.enum.js';
 
-@Controller('user/profile')
+@Controller('user')
 @UseGuards(JwtAuthGuard)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @Post()
+  @Get()
+  async getMe(
+    @Req() req: Request & { user: JwtAccessTokenPayload },
+  ): Promise<UserResponseDto> {
+    const user = await this.usersService.findById(req.user.sub);
+    return UserResponseDto.fromEntity(user);
+  }
+
+  @Patch()
+  async updateMe(
+    @Body() dto: UpdateUserDto,
+    @Req() req: Request & { user: JwtAccessTokenPayload },
+  ): Promise<UserResponseDto> {
+    const user = await this.usersService.updateUser(req.user.sub, dto);
+    return UserResponseDto.fromEntity(user);
+  }
+
+  @Delete()
+  @HttpCode(HttpStatus.OK)
+  async deleteMe(
+    @Req() req: Request & { user: JwtAccessTokenPayload },
+  ): Promise<UserResponseDto> {
+    const user = await this.usersService.deactivateUser(req.user.sub);
+    return UserResponseDto.fromEntity(user);
+  }
+
+  @Get('admin')
+  @UseGuards(RolesGuard)
+  @Roles(AuthRole.ADMIN)
+  async listUsers(@Query() query: UserQueryDto) {
+    const result = await this.usersService.findAll(query);
+    return {
+      ...result,
+      data: result.data.map((user) => UserResponseDto.fromEntity(user)),
+    };
+  }
+
+  @Post('profile')
   @HttpCode(HttpStatus.CREATED)
   async createProfile(
     @Body() dto: CreateProfileDto,
@@ -40,7 +85,7 @@ export class UsersController {
     return this.usersService.createMenteeProfile(userId, dto.menteeData ?? {});
   }
 
-  @Patch(':type')
+  @Patch('profile/:type')
   @Throttle({ default: { limit: 30, ttl: 3600000 } })
   async updateProfile(
     @Param('type') type: string,
@@ -69,7 +114,7 @@ export class UsersController {
     return { message: 'Invalid profile type. Must be "mentor" or "mentee".' };
   }
 
-  @Get(':type')
+  @Get('profile/:type')
   async getProfile(
     @Param('type') type: string,
     @Req() req: Request & { user: JwtAccessTokenPayload },

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -9,6 +9,7 @@ import { Role } from './entities/role.entity.js';
 import { MentorProfile } from './entities/mentor-profile.entity.js';
 import { MenteeProfile } from './entities/mentee-profile.entity.js';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard.js';
+import { RolesGuard } from '../auth/guards/roles.guard.js';
 
 @Module({
   imports: [
@@ -24,7 +25,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard.js';
     ConfigModule,
   ],
   controllers: [UsersController],
-  providers: [UsersService, JwtAuthGuard],
+  providers: [UsersService, JwtAuthGuard, RolesGuard],
   exports: [UsersService],
 })
 export class UsersModule {}

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -21,6 +21,7 @@ describe('UsersService', () => {
     findOne: jest.fn(),
     create: jest.fn(),
     save: jest.fn(),
+    findAndCount: jest.fn(),
   };
 
   const mockRoleRepo = {
@@ -383,6 +384,99 @@ describe('UsersService', () => {
       await expect(service.getMenteeProfile('user-1')).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('updateUser', () => {
+    it('should update user fields and save', async () => {
+      const existingUser = { ...mockUser, email: undefined };
+      mockUserRepo.findOne
+        .mockResolvedValueOnce(existingUser)
+        .mockResolvedValueOnce(null);
+      mockUserRepo.save.mockImplementation((u) => Promise.resolve(u));
+
+      const result = await service.updateUser('user-1', {
+        displayName: 'New Name',
+        email: 'new@example.com',
+      });
+
+      expect(result.displayName).toBe('New Name');
+      expect(result.email).toBe('new@example.com');
+      expect(mockUserRepo.save).toHaveBeenCalled();
+    });
+
+    it('should throw ConflictException when email is already taken', async () => {
+      const existingUser = { ...mockUser, email: undefined };
+      mockUserRepo.findOne
+        .mockResolvedValueOnce(existingUser)
+        .mockResolvedValueOnce({
+          id: 'other-user',
+          email: 'taken@example.com',
+        });
+
+      await expect(
+        service.updateUser('user-1', { email: 'taken@example.com' }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      mockUserRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateUser('missing-user', { displayName: 'X' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deactivateUser', () => {
+    it('should set status to deleted and save', async () => {
+      const existingUser = { ...mockUser, status: UserStatus.ACTIVE };
+      mockUserRepo.findOne.mockResolvedValue(existingUser);
+      mockUserRepo.save.mockImplementation((u) => Promise.resolve(u));
+
+      const result = await service.deactivateUser('user-1');
+
+      expect(result.status).toBe(UserStatus.DELETED);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated users', async () => {
+      mockUserRepo.findAndCount.mockResolvedValue([[mockUser], 1]);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result).toEqual({
+        data: [mockUser],
+        total: 1,
+        page: 1,
+        limit: 20,
+      });
+      expect(mockUserRepo.findAndCount).toHaveBeenCalledWith({
+        where: {},
+        relations: ['roles'],
+        skip: 0,
+        take: 20,
+        order: { createdAt: 'DESC' },
+      });
+    });
+
+    it('should filter by status when provided', async () => {
+      mockUserRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({
+        status: UserStatus.SUSPENDED,
+        page: 2,
+        limit: 10,
+      });
+
+      expect(mockUserRepo.findAndCount).toHaveBeenCalledWith({
+        where: { status: UserStatus.SUSPENDED },
+        relations: ['roles'],
+        skip: 10,
+        take: 10,
+        order: { createdAt: 'DESC' },
+      });
     });
   });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -15,6 +15,9 @@ import { CreateMentorProfileDto } from './dto/create-mentor-profile.dto.js';
 import { CreateMenteeProfileDto } from './dto/create-mentee-profile.dto.js';
 import { UpdateMentorProfileDto } from './dto/update-mentor-profile.dto.js';
 import { UpdateMenteeProfileDto } from './dto/update-mentee-profile.dto.js';
+import { UpdateUserDto } from './dto/update-user.dto.js';
+import { UserQueryDto } from './dto/user-query.dto.js';
+import { UserStatus } from './enums/user-status.enum.js';
 import { AuthRole } from '../common/enums/auth-role.enum.js';
 
 interface FieldChange {
@@ -271,5 +274,71 @@ export class UsersService {
       throw new NotFoundException('Mentee profile not found');
     }
     return profile;
+  }
+
+  async updateUser(userId: string, dto: UpdateUserDto): Promise<User> {
+    const user = await this.findById(userId);
+
+    if (dto.email && dto.email !== user.email) {
+      const existing = await this.userRepo.findOne({
+        where: { email: dto.email },
+      });
+      if (existing && existing.id !== userId) {
+        throw new ConflictException('Email is already in use');
+      }
+    }
+
+    const changes = this.applyChanges(
+      user as unknown as Record<string, unknown>,
+      dto as Record<string, unknown>,
+    );
+
+    const saved = await this.userRepo.save(user);
+
+    if (Object.keys(changes).length > 0) {
+      this.logger.log(
+        JSON.stringify({
+          event: 'USER_UPDATED',
+          userId,
+          changes,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+    }
+
+    return saved;
+  }
+
+  async deactivateUser(userId: string): Promise<User> {
+    const user = await this.findById(userId);
+    user.status = UserStatus.DELETED;
+    const saved = await this.userRepo.save(user);
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'USER_DEACTIVATED',
+        userId,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
+    return saved;
+  }
+
+  async findAll(
+    query: UserQueryDto,
+  ): Promise<{ data: User[]; total: number; page: number; limit: number }> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+
+    const [data, total] = await this.userRepo.findAndCount({
+      where: query.status ? { status: query.status } : {},
+      relations: ['roles'],
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { createdAt: 'DESC' },
+    });
+
+    return { data, total, page, limit };
   }
 }

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('UsersController (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  it('/user (GET) rejects requests without a token', () => {
+    return request(app.getHttpServer()).get('/user').expect(401);
+  });
+
+  it('/user (PATCH) rejects requests without a token', () => {
+    return request(app.getHttpServer())
+      .patch('/user')
+      .send({ displayName: 'New Name' })
+      .expect(401);
+  });
+
+  it('/user (DELETE) rejects requests without a token', () => {
+    return request(app.getHttpServer()).delete('/user').expect(401);
+  });
+
+  it('/user/admin (GET) rejects requests without a token', () => {
+    return request(app.getHttpServer()).get('/user/admin').expect(401);
+  });
+});


### PR DESCRIPTION
Closes #986

Rounds out the User module to match the module scaffolding checklist:

- Added `email` column to the `users` table (nullable, unique) with migration
- Added `GET/PATCH/DELETE /user` endpoints for the caller's own account, alongside the existing mentor/mentee profile routes under `/user/profile/*`
- Added `GET /user/admin` paginated user listing, restricted to the admin role
- Added `UpdateUserDto`, `UserResponseDto`, and `UserQueryDto`
- Extended unit tests for the new controller/service methods and added an e2e spec for the account routes