### PR TITLE
feat(contract): standardize ContractError codes (init/authz/session)

### DIFF
--- a/contract/docs/errors.md
+++ b/contract/docs/errors.md
@@ -38,6 +38,9 @@ the range 0-255. Codes are grouped into reserved ranges by category:
 | Code | Variant        | Meaning                          |
 |------|-----------------|-----------------------------------|
 | 200  | `Unauthorized` | Generic unauthorized access.      |
+| 201  | `NotAdmin`     | Caller is not contract admin.     |
+| 202  | `NotBuyer`     | Caller is not session buyer.      |
+| 203  | `NotSeller`    | Caller is not session seller.     |
 
 ## Session validation (300-399)
 

--- a/contract/docs/errors.md
+++ b/contract/docs/errors.md
@@ -1,0 +1,45 @@
+# Contract error codes
+
+`ContractError` (`contract/src/lib.rs`) is the single error enum used across
+the SkillSync Soroban contract. Every variant has a unique numeric code in
+the range 0-255. Codes are grouped into reserved ranges by category:
+
+| Range   | Category                  |
+|---------|----------------------------|
+| 0-99    | General / uncategorized    |
+| 100-199 | Initialization errors      |
+| 200-299 | Authorization errors       |
+| 300-399 | Session validation errors  |
+
+## General (0-99)
+
+| Code | Variant                | Meaning                                   |
+|------|-------------------------|--------------------------------------------|
+| 6    | `AmountMustBePositive`  | Session amount must be greater than zero. |
+| 7    | `InvalidStatus`         | Operation not valid for current status.   |
+| 8    | `SharesMismatch`        | Buyer/seller shares don't sum to amount.  |
+| 9    | `TransferFailed`        | Token transfer failed.                    |
+| 10   | `FeeExceedsAmount`      | Platform fee exceeds the session amount.  |
+| 11   | `FeeTooHigh`            | Requested platform fee exceeds the cap.   |
+| 12   | `AlreadyArchived`       | Session has already been archived.        |
+| 13   | `NotArchived`           | Session has not been archived.            |
+
+## Initialization (100-199)
+
+| Code | Variant              | Meaning                              |
+|------|-----------------------|----------------------------------------|
+| 100  | `AlreadyInitialized` | Contract already initialized.         |
+| 101  | `NotInitialized`     | Contract not initialized yet.         |
+
+## Authorization (200-299)
+
+| Code | Variant        | Meaning                          |
+|------|-----------------|-----------------------------------|
+| 200  | `Unauthorized` | Generic unauthorized access.      |
+
+## Session validation (300-399)
+
+| Code | Variant                | Meaning                          |
+|------|--------------------------|-------------------------------------|
+| 300  | `SessionNotFound`      | Session ID does not exist.        |
+| 301  | `SessionAlreadyExists` | Session ID already exists.        |

--- a/contract/docs/errors.md
+++ b/contract/docs/errors.md
@@ -44,7 +44,12 @@ the range 0-255. Codes are grouped into reserved ranges by category:
 
 ## Session validation (300-399)
 
-| Code | Variant                | Meaning                          |
-|------|--------------------------|-------------------------------------|
-| 300  | `SessionNotFound`      | Session ID does not exist.        |
-| 301  | `SessionAlreadyExists` | Session ID already exists.        |
+| Code | Variant                    | Meaning                                  |
+|------|------------------------------|---------------------------------------------|
+| 300  | `SessionNotFound`          | Session ID does not exist.                |
+| 301  | `DuplicateSessionId`       | Session ID already exists.                |
+| 302  | `InvalidSessionState`      | Operation not allowed in current state.   |
+| 303  | `SessionAlreadyCompleted`  | Cannot complete again.                    |
+| 304  | `SessionAlreadyApproved`   | Cannot approve twice.                     |
+| 305  | `SessionAlreadyRefunded`   | Session already refunded.                 |
+| 306  | `SessionInDispute`         | Cannot act while disputed.                |

--- a/contract/docs/errors.md
+++ b/contract/docs/errors.md
@@ -26,10 +26,12 @@ the range 0-255. Codes are grouped into reserved ranges by category:
 
 ## Initialization (100-199)
 
-| Code | Variant              | Meaning                              |
-|------|-----------------------|----------------------------------------|
-| 100  | `AlreadyInitialized` | Contract already initialized.         |
-| 101  | `NotInitialized`     | Contract not initialized yet.         |
+| Code | Variant              | Meaning                                |
+|------|-----------------------|------------------------------------------|
+| 100  | `AlreadyInitialized` | Contract already initialized.           |
+| 101  | `NotInitialized`     | Contract not initialized yet.           |
+| 102  | `InvalidAdmin`       | Admin address is zero or invalid.       |
+| 103  | `InvalidTreasury`    | Treasury address is zero or invalid.    |
 
 ## Authorization (200-299)
 

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -49,6 +49,9 @@ pub enum ContractError {
 
     // -- Authorization (200-299) --
     Unauthorized         = 200,
+    NotAdmin             = 201,
+    NotBuyer             = 202,
+    NotSeller            = 203,
 
     // -- Session validation (300-399) --
     SessionNotFound      = 300,

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -44,6 +44,8 @@ pub enum ContractError {
     // -- Initialization (100-199) --
     AlreadyInitialized   = 100,
     NotInitialized       = 101,
+    InvalidAdmin         = 102,
+    InvalidTreasury      = 103,
 
     // -- Authorization (200-299) --
     Unauthorized         = 200,

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -54,8 +54,13 @@ pub enum ContractError {
     NotSeller            = 203,
 
     // -- Session validation (300-399) --
-    SessionNotFound      = 300,
-    SessionAlreadyExists = 301,
+    SessionNotFound          = 300,
+    DuplicateSessionId       = 301,
+    InvalidSessionState      = 302,
+    SessionAlreadyCompleted  = 303,
+    SessionAlreadyApproved   = 304,
+    SessionAlreadyRefunded   = 305,
+    SessionInDispute         = 306,
 }
 
 // ---------------------------------------------------------------------------
@@ -202,7 +207,7 @@ impl SkillsyncContract {
             panic_with_error!(&env, ContractError::AmountMustBePositive);
         }
         if get_session(&env, &session_id).is_some() {
-            panic_with_error!(&env, ContractError::SessionAlreadyExists);
+            panic_with_error!(&env, ContractError::DuplicateSessionId);
         }
         buyer.require_auth();
         let session = Session {

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -18,15 +18,20 @@ const ARCHIVE_AFTER: &str = "ARCHAFT";
 
 // ---------------------------------------------------------------------------
 // Error codes
+//
+// Standard error codes for the contract. Codes are unique across the whole
+// enum and grouped into reserved ranges by category; see
+// `contract/docs/errors.md` for the full spec.
+//
+//   0-99    General / uncategorized errors
+//   100-199 Initialization errors
+//   200-299 Authorization errors
+//   300-399 Session validation errors
 // ---------------------------------------------------------------------------
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum ContractError {
-    AlreadyInitialized   = 1,
-    NotInitialized       = 2,
-    Unauthorized         = 3,
-    SessionAlreadyExists = 4,
-    SessionNotFound      = 5,
+    // -- General (0-99) --
     AmountMustBePositive = 6,
     InvalidStatus        = 7,
     SharesMismatch       = 8,
@@ -35,6 +40,17 @@ pub enum ContractError {
     FeeTooHigh           = 11,
     AlreadyArchived      = 12,
     NotArchived          = 13,
+
+    // -- Initialization (100-199) --
+    AlreadyInitialized   = 100,
+    NotInitialized       = 101,
+
+    // -- Authorization (200-299) --
+    Unauthorized         = 200,
+
+    // -- Session validation (300-399) --
+    SessionNotFound      = 300,
+    SessionAlreadyExists = 301,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Defines the standard `ContractError` enum for the Soroban contract and organizes it into reserved numeric ranges, per issues #936, #937, #938, #939.

- **#936 — Define error codes enum**: Reorganized `ContractError` into commented sections by category and reserved numeric ranges (0-99 general, 100-199 init, 200-299 authz, 300-399 session). Added `contract/docs/errors.md` documenting every code. The enum already derives `Debug` (via `#[derive(... Debug ...)]`) and gets `Into<soroban_sdk::Error>` for free from the `#[contracterror]` macro.
- **#937 — Initialization errors**: Added `InvalidAdmin = 102` and `InvalidTreasury = 103`. Kept existing `AlreadyInitialized = 100` and `NotInitialized = 101`.
- **#938 — Authorization errors**: Added `Unauthorized = 200` (kept), `NotAdmin = 201`, `NotBuyer = 202`, `NotSeller = 203`.
- **#939 — Session validation errors**: Kept `SessionNotFound = 300`, renamed `SessionAlreadyExists` to `DuplicateSessionId = 301` (same meaning: "Session ID already exists"; updated its one call site in `create_session`). Added `InvalidSessionState = 302`, `SessionAlreadyCompleted = 303`, `SessionAlreadyApproved = 304`, `SessionAlreadyRefunded = 305`, `SessionInDispute = 306`.

Pre-existing general error codes unrelated to these issues (`AmountMustBePositive`, `InvalidStatus`, `SharesMismatch`, `TransferFailed`, `FeeExceedsAmount`, `FeeTooHigh`, `AlreadyArchived`, `NotArchived`) were left untouched, numbers unchanged.

Note: the newly added variants (`InvalidAdmin`, `InvalidTreasury`, `NotAdmin`, `NotBuyer`, `NotSeller`, `InvalidSessionState`, `SessionAlreadyCompleted`, `SessionAlreadyApproved`, `SessionAlreadyRefunded`, `SessionInDispute`) are defined per spec but not yet wired into contract logic — that wiring wasn't part of these issues' acceptance criteria.

## Commits

- `feat(contract): organize ContractError enum into ranges, add error spec (#936)`
- `feat(contract): add initialization error codes (#937)`
- `feat(contract): add authorization error codes (#938)`
- `feat(contract): add session validation error codes (#939)`

Closes #936
Closes #937
Closes #938
Closes #939

## Test plan

- [ ] No Rust toolchain was available in the dev environment used for this change, so `cargo build` / `cargo test` were not run here — please verify compilation and existing tests (`cargo test -p skillsync_contract`) before merging.