### PR TITLE
feat: financial/dispute error codes, user status, and username support

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { JwtStrategy } from './strategies/jwt.strategy.js';
 import { WalletStrategy } from './strategies/wallet.strategy.js';
 import { JwtAuthGuard } from './guards/jwt-auth.guard.js';
 import { RolesGuard } from './guards/roles.guard.js';
+import { UsersModule } from '../users/users.module.js';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { RolesGuard } from './guards/roles.guard.js';
       }),
       inject: [ConfigService],
     }),
+    UsersModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy, WalletStrategy, JwtAuthGuard, RolesGuard],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -4,6 +4,8 @@ import { ConfigService } from '@nestjs/config';
 import { v4 as uuidv4 } from 'uuid';
 import { JwtAccessTokenPayload } from './interfaces/jwt-payload.interface.js';
 import { WalletStrategy } from './strategies/wallet.strategy.js';
+import { UsersService } from '../users/users.service.js';
+import { AuthRole } from '../common/enums/auth-role.enum.js';
 
 /**
  * #971-978: Auth service handling wallet login, JWT lifecycle, and session management.
@@ -41,6 +43,7 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly walletStrategy: WalletStrategy,
+    private readonly usersService: UsersService,
   ) {}
 
   /**
@@ -105,15 +108,19 @@ export class AuthService {
     const accessTtl = parseInt(this.configService.get('JWT_ACCESS_TTL', '900'), 10); // 15 min
     const refreshTtl = parseInt(this.configService.get('JWT_REFRESH_TTL', '604800'), 10); // 7 days
 
-    const roles = await this.resolveRoles(walletAddress);
+    const user = await this.usersService.findOrCreateByWallet(walletAddress);
+    const roles = user.roles?.length
+      ? user.roles.map((role) => role.name)
+      : [AuthRole.MENTEE];
 
     const accessPayload: JwtAccessTokenPayload = {
-      sub: walletAddress,
+      sub: user.id,
       wallet: walletAddress,
       jti: accessJti,
       iat: Math.floor(Date.now() / 1000),
       exp: Math.floor(Date.now() / 1000) + accessTtl,
       roles,
+      status: user.status,
     };
 
     const accessToken = await this.jwtService.signAsync(accessPayload);
@@ -197,12 +204,6 @@ export class AuthService {
   seedAdmin(walletAddress: string): void {
     this.logger.log(`Admin seeded for ${walletAddress.slice(0, 8)}...`);
     // In production: persist to database via UsersService
-  }
-
-  private async resolveRoles(walletAddress: string): Promise<string[]> {
-    // In production: query from database
-    // Default role for all authenticated users
-    return ['MENTEE'];
   }
 
   private cleanExpiredNonces(): void {

--- a/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
 import { JwtAccessTokenPayload } from '../interfaces/jwt-payload.interface';
+import { UserStatus } from '../../users/enums/user-status.enum.js';
 
 /**
  * #981: Enhanced JWT Auth Guard.
@@ -54,6 +55,13 @@ export class JwtAuthGuard implements CanActivate {
             code: 'token_revoked',
           });
         }
+      }
+
+      if (payload.status && payload.status !== UserStatus.ACTIVE) {
+        throw new UnauthorizedException({
+          message: 'Account is not active',
+          code: 'account_not_active',
+        });
       }
 
       req.user = payload;

--- a/backend/src/auth/interfaces/jwt-payload.interface.ts
+++ b/backend/src/auth/interfaces/jwt-payload.interface.ts
@@ -1,3 +1,5 @@
+import { UserStatus } from '../../users/enums/user-status.enum.js';
+
 export interface JwtAccessTokenPayload {
   sub: string;
   wallet: string;
@@ -5,4 +7,5 @@ export interface JwtAccessTokenPayload {
   iat: number;
   exp: number;
   roles?: string[];
+  status: UserStatus;
 }

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -29,6 +29,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       iat: payload.iat,
       exp: payload.exp,
       roles: payload.roles || [],
+      status: payload.status,
     };
   }
 }

--- a/backend/src/database/migrations/1722400000000-AddPendingVerificationToUserStatusEnum.ts
+++ b/backend/src/database/migrations/1722400000000-AddPendingVerificationToUserStatusEnum.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * #1002: Adds 'pending_verification' to the user_status_enum for users who
+ * have not yet completed email verification.
+ */
+export class AddPendingVerificationToUserStatusEnum1722400000000
+  implements MigrationInterface
+{
+  name = 'AddPendingVerificationToUserStatusEnum1722400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TYPE "user_status_enum" ADD VALUE IF NOT EXISTS 'pending_verification'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Postgres does not support removing enum values directly; rebuild the type.
+    await queryRunner.query(`
+      ALTER TYPE "user_status_enum" RENAME TO "user_status_enum_old"
+    `);
+    await queryRunner.query(`
+      CREATE TYPE "user_status_enum" AS ENUM ('active', 'suspended', 'deleted')
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "users"
+        ALTER COLUMN "status" DROP DEFAULT,
+        ALTER COLUMN "status" TYPE "user_status_enum" USING "status"::text::"user_status_enum",
+        ALTER COLUMN "status" SET DEFAULT 'active'
+    `);
+    await queryRunner.query(`DROP TYPE "user_status_enum_old"`);
+  }
+}

--- a/backend/src/database/migrations/1722500000000-AddUsernameUniqueAndCooldown.ts
+++ b/backend/src/database/migrations/1722500000000-AddUsernameUniqueAndCooldown.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * #1003: Enforces unique usernames at the database level and tracks the
+ * last username change so the 30-day cooldown can be validated.
+ */
+export class AddUsernameUniqueAndCooldown1722500000000
+  implements MigrationInterface
+{
+  name = 'AddUsernameUniqueAndCooldown1722500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users"
+        ALTER COLUMN "username" TYPE varchar(30),
+        ADD COLUMN IF NOT EXISTS "usernameChangedAt" timestamp NULL
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "users"
+        ADD CONSTRAINT "UQ_users_username" UNIQUE ("username")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users" DROP CONSTRAINT IF EXISTS "UQ_users_username"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "users" DROP COLUMN IF EXISTS "usernameChangedAt"
+    `);
+  }
+}

--- a/backend/src/users/dto/public-profile-response.dto.ts
+++ b/backend/src/users/dto/public-profile-response.dto.ts
@@ -1,0 +1,21 @@
+import { User } from '../entities/user.entity.js';
+import { AuthRole } from '../../common/enums/auth-role.enum.js';
+
+/** #1003: Public-facing profile — excludes wallet address, email, and status. */
+export class PublicProfileResponseDto {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+  roles: AuthRole[];
+  createdAt: Date;
+
+  static fromEntity(user: User): PublicProfileResponseDto {
+    const dto = new PublicProfileResponseDto();
+    dto.id = user.id;
+    dto.username = user.username ?? null;
+    dto.displayName = user.displayName ?? null;
+    dto.roles = (user.roles ?? []).map((role) => role.name);
+    dto.createdAt = user.createdAt;
+    return dto;
+  }
+}

--- a/backend/src/users/dto/update-user-status.dto.ts
+++ b/backend/src/users/dto/update-user-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { UserStatus } from '../enums/user-status.enum.js';
+
+export class UpdateUserStatusDto {
+  @IsEnum(UserStatus)
+  status: UserStatus;
+}

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -3,12 +3,7 @@ import { IsEmail, IsOptional, IsString, MaxLength } from 'class-validator';
 export class UpdateUserDto {
   @IsOptional()
   @IsString()
-  @MaxLength(100)
-  username?: string;
-
-  @IsOptional()
-  @IsString()
-  @MaxLength(150)
+  @MaxLength(50)
   displayName?: string;
 
   @IsOptional()

--- a/backend/src/users/dto/update-username.dto.ts
+++ b/backend/src/users/dto/update-username.dto.ts
@@ -1,0 +1,17 @@
+import { IsString, Length, Matches } from 'class-validator';
+
+/**
+ * #1003: alphanumeric + underscore/dash, 3-30 chars, no leading/trailing or
+ * consecutive special characters.
+ */
+export const USERNAME_PATTERN = /^[a-zA-Z0-9]+(?:[_-][a-zA-Z0-9]+)*$/;
+
+export class UpdateUsernameDto {
+  @IsString()
+  @Length(3, 30)
+  @Matches(USERNAME_PATTERN, {
+    message:
+      'username must be alphanumeric with optional single underscores/dashes between characters',
+  })
+  username: string;
+}

--- a/backend/src/users/dto/username-availability-query.dto.ts
+++ b/backend/src/users/dto/username-availability-query.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, Length, Matches } from 'class-validator';
+import { USERNAME_PATTERN } from './update-username.dto.js';
+
+export class UsernameAvailabilityQueryDto {
+  @IsString()
+  @Length(3, 30)
+  @Matches(USERNAME_PATTERN, {
+    message:
+      'username must be alphanumeric with optional single underscores/dashes between characters',
+  })
+  username: string;
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -20,13 +20,16 @@ export class User {
   @Column({ type: 'varchar', length: 256 })
   walletAddress: string;
 
-  @Column({ type: 'varchar', nullable: true })
+  @Column({ type: 'varchar', length: 30, nullable: true, unique: true })
   username: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  usernameChangedAt: Date | null;
 
   @Column({ type: 'varchar', length: 255, nullable: true, unique: true })
   email: string;
 
-  @Column({ type: 'varchar', nullable: true })
+  @Column({ type: 'varchar', length: 50, nullable: true })
   displayName: string;
 
   @Column({

--- a/backend/src/users/enums/user-status.enum.ts
+++ b/backend/src/users/enums/user-status.enum.ts
@@ -1,5 +1,6 @@
 export enum UserStatus {
   ACTIVE = 'active',
+  PENDING_VERIFICATION = 'pending_verification',
   SUSPENDED = 'suspended',
   DELETED = 'deleted',
 }

--- a/backend/src/users/profiles.controller.ts
+++ b/backend/src/users/profiles.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
+import { UsersService } from './users.service.js';
+import { PublicProfileResponseDto } from './dto/public-profile-response.dto.js';
+import { UserStatus } from './enums/user-status.enum.js';
+
+/** #1003: Public profile lookup by username. No auth required. */
+@Controller('profiles')
+export class ProfilesController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get(':username')
+  async getByUsername(
+    @Param('username') username: string,
+  ): Promise<PublicProfileResponseDto> {
+    const user = await this.usersService.findByUsername(username);
+    if (!user || user.status !== UserStatus.ACTIVE) {
+      throw new NotFoundException('Profile not found');
+    }
+    return PublicProfileResponseDto.fromEntity(user);
+  }
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -10,6 +10,7 @@ import {
   Post,
   Query,
   Req,
+  UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
@@ -19,6 +20,8 @@ import { UpdateMentorProfileDto } from './dto/update-mentor-profile.dto.js';
 import { UpdateMenteeProfileDto } from './dto/update-mentee-profile.dto.js';
 import { UpdateUserDto } from './dto/update-user.dto.js';
 import { UpdateUserStatusDto } from './dto/update-user-status.dto.js';
+import { UpdateUsernameDto } from './dto/update-username.dto.js';
+import { UsernameAvailabilityQueryDto } from './dto/username-availability-query.dto.js';
 import { UserQueryDto } from './dto/user-query.dto.js';
 import { UserResponseDto } from './dto/user-response.dto.js';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard.js';
@@ -81,6 +84,33 @@ export class UsersController {
       id,
       dto.status,
       req.user.sub,
+    );
+    return UserResponseDto.fromEntity(user);
+  }
+
+  @Get('username/available')
+  async checkUsernameAvailability(
+    @Query() query: UsernameAvailabilityQueryDto,
+    @Req() req: Request & { user?: JwtAccessTokenPayload },
+  ): Promise<{ available: boolean }> {
+    const available = await this.usersService.isUsernameAvailable(
+      query.username,
+      req.user?.sub,
+    );
+    return { available };
+  }
+
+  @Patch('username')
+  async updateUsername(
+    @Body() dto: UpdateUsernameDto,
+    @Req() req: Request & { user?: JwtAccessTokenPayload },
+  ): Promise<UserResponseDto> {
+    if (!req.user) {
+      throw new UnauthorizedException();
+    }
+    const user = await this.usersService.updateUsername(
+      req.user.sub,
+      dto.username,
     );
     return UserResponseDto.fromEntity(user);
   }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -18,6 +18,7 @@ import { CreateProfileDto } from './dto/create-profile.dto.js';
 import { UpdateMentorProfileDto } from './dto/update-mentor-profile.dto.js';
 import { UpdateMenteeProfileDto } from './dto/update-mentee-profile.dto.js';
 import { UpdateUserDto } from './dto/update-user.dto.js';
+import { UpdateUserStatusDto } from './dto/update-user-status.dto.js';
 import { UserQueryDto } from './dto/user-query.dto.js';
 import { UserResponseDto } from './dto/user-response.dto.js';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard.js';
@@ -66,6 +67,22 @@ export class UsersController {
       ...result,
       data: result.data.map((user) => UserResponseDto.fromEntity(user)),
     };
+  }
+
+  @Patch('admin/:id/status')
+  @UseGuards(RolesGuard)
+  @Roles(AuthRole.ADMIN)
+  async updateUserStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateUserStatusDto,
+    @Req() req: Request & { user: JwtAccessTokenPayload },
+  ): Promise<UserResponseDto> {
+    const user = await this.usersService.updateStatus(
+      id,
+      dto.status,
+      req.user.sub,
+    );
+    return UserResponseDto.fromEntity(user);
   }
 
   @Post('profile')

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { UsersController } from './users.controller.js';
+import { ProfilesController } from './profiles.controller.js';
 import { UsersService } from './users.service.js';
 import { User } from './entities/user.entity.js';
 import { Role } from './entities/role.entity.js';
@@ -24,7 +25,7 @@ import { RolesGuard } from '../auth/guards/roles.guard.js';
     }),
     ConfigModule,
   ],
-  controllers: [UsersController],
+  controllers: [UsersController, ProfilesController],
   providers: [UsersService, JwtAuthGuard, RolesGuard],
   exports: [UsersService],
 })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -7,7 +7,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Not, Repository } from 'typeorm';
 import { User } from './entities/user.entity.js';
 import { Role } from './entities/role.entity.js';
 import { MentorProfile } from './entities/mentor-profile.entity.js';
@@ -65,8 +65,76 @@ export class UsersService {
       return existing;
     }
 
-    const created = this.userRepo.create({ walletAddress });
+    const created = this.userRepo.create({
+      walletAddress,
+      displayName: walletAddress.slice(0, 10),
+    });
     return this.userRepo.save(created);
+  }
+
+  /** #1003: Case-sensitive availability check against the unique username column. */
+  async isUsernameAvailable(
+    username: string,
+    excludeUserId?: string,
+  ): Promise<boolean> {
+    const existing = await this.userRepo.findOne({
+      where: excludeUserId
+        ? { username, id: Not(excludeUserId) }
+        : { username },
+    });
+    return !existing;
+  }
+
+  async findByUsername(username: string): Promise<User | null> {
+    return this.userRepo.findOne({
+      where: { username },
+      relations: ['roles'],
+    });
+  }
+
+  private static readonly USERNAME_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
+
+  /** #1003: Change username, enforcing uniqueness and a 30-day cooldown. */
+  async updateUsername(userId: string, newUsername: string): Promise<User> {
+    const user = await this.findById(userId);
+
+    if (user.username === newUsername) {
+      return user;
+    }
+
+    if (user.usernameChangedAt) {
+      const elapsed = Date.now() - user.usernameChangedAt.getTime();
+      if (elapsed < UsersService.USERNAME_COOLDOWN_MS) {
+        const daysLeft = Math.ceil(
+          (UsersService.USERNAME_COOLDOWN_MS - elapsed) / (24 * 60 * 60 * 1000),
+        );
+        throw new ForbiddenException(
+          `Username can be changed again in ${daysLeft} day(s)`,
+        );
+      }
+    }
+
+    const available = await this.isUsernameAvailable(newUsername, userId);
+    if (!available) {
+      throw new ConflictException('Username is already taken');
+    }
+
+    const oldUsername = user.username;
+    user.username = newUsername;
+    user.usernameChangedAt = new Date();
+    const saved = await this.userRepo.save(user);
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'USERNAME_CHANGED',
+        userId,
+        oldUsername,
+        newUsername,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
+    return saved;
   }
 
   async createMentorProfile(

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   Injectable,
@@ -49,6 +50,23 @@ export class UsersService {
       throw new NotFoundException('User not found');
     }
     return user;
+  }
+
+  /**
+   * Find the user for a wallet address, creating one with default status
+   * if this is their first login.
+   */
+  async findOrCreateByWallet(walletAddress: string): Promise<User> {
+    const existing = await this.userRepo.findOne({
+      where: { walletAddress },
+      relations: ['roles'],
+    });
+    if (existing) {
+      return existing;
+    }
+
+    const created = this.userRepo.create({ walletAddress });
+    return this.userRepo.save(created);
   }
 
   async createMentorProfile(
@@ -305,6 +323,52 @@ export class UsersService {
         }),
       );
     }
+
+    return saved;
+  }
+
+  private static readonly ALLOWED_STATUS_TRANSITIONS: Record<
+    UserStatus,
+    UserStatus[]
+  > = {
+    [UserStatus.PENDING_VERIFICATION]: [UserStatus.ACTIVE, UserStatus.DELETED],
+    [UserStatus.ACTIVE]: [UserStatus.SUSPENDED, UserStatus.DELETED],
+    [UserStatus.SUSPENDED]: [UserStatus.ACTIVE, UserStatus.DELETED],
+    [UserStatus.DELETED]: [],
+  };
+
+  async updateStatus(
+    userId: string,
+    newStatus: UserStatus,
+    adminId: string,
+  ): Promise<User> {
+    const user = await this.findById(userId);
+
+    if (user.status === newStatus) {
+      return user;
+    }
+
+    const allowed = UsersService.ALLOWED_STATUS_TRANSITIONS[user.status] ?? [];
+    if (!allowed.includes(newStatus)) {
+      throw new BadRequestException(
+        `Cannot transition user status from '${user.status}' to '${newStatus}'`,
+      );
+    }
+
+    const oldStatus = user.status;
+    user.status = newStatus;
+    const saved = await this.userRepo.save(user);
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'USER_STATUS_CHANGED',
+        userId,
+        oldStatus,
+        newStatus,
+        changedBy: adminId,
+        timestamp: new Date().toISOString(),
+      }),
+    );
 
     return saved;
   }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -27,14 +27,33 @@ pub enum ContractError {
     Unauthorized         = 3,
     SessionAlreadyExists = 4,
     SessionNotFound      = 5,
-    AmountMustBePositive = 6,
     InvalidStatus        = 7,
-    SharesMismatch       = 8,
     TransferFailed       = 9,
     FeeExceedsAmount     = 10,
-    FeeTooHigh           = 11,
     AlreadyArchived      = 12,
     NotArchived          = 13,
+
+    // -- Financial validation errors (#940) --------------------------------
+    /// Amount is zero or negative.
+    InvalidAmount           = 400,
+    /// Buyer has insufficient funds.
+    InsufficientBalance     = 401,
+    /// Fee exceeds maximum (1000 bps).
+    FeeTooHigh              = 402,
+    /// Dispute split does not sum to amount.
+    InvalidSplit            = 403,
+    /// Arithmetic overflow detected.
+    Overflow                = 404,
+
+    // -- Timeout and dispute errors (#941) ----------------------------------
+    /// Cannot auto-refund yet.
+    DisputeWindowNotElapsed = 500,
+    /// Dispute already exists for session.
+    DisputeAlreadyOpen      = 501,
+    /// No open dispute to resolve.
+    DisputeNotOpen          = 502,
+    /// Session not eligible for resolution.
+    ResolutionNotAllowed    = 503,
 }
 
 // ---------------------------------------------------------------------------
@@ -178,7 +197,7 @@ impl SkillsyncContract {
     ) {
         require_initialized(&env);
         if amount <= 0 {
-            panic_with_error!(&env, ContractError::AmountMustBePositive);
+            panic_with_error!(&env, ContractError::InvalidAmount);
         }
         if get_session(&env, &session_id).is_some() {
             panic_with_error!(&env, ContractError::SessionAlreadyExists);
@@ -239,6 +258,9 @@ impl SkillsyncContract {
         require_initialized(&env);
         let mut session = get_session(&env, &session_id)
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::SessionNotFound));
+        if session.status == SessionStatus::Disputed {
+            panic_with_error!(&env, ContractError::DisputeAlreadyOpen);
+        }
         if session.status != SessionStatus::Locked && session.status != SessionStatus::Completed {
             panic_with_error!(&env, ContractError::InvalidStatus);
         }
@@ -259,10 +281,10 @@ impl SkillsyncContract {
         let mut session = get_session(&env, &session_id)
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::SessionNotFound));
         if session.status != SessionStatus::Disputed {
-            panic_with_error!(&env, ContractError::InvalidStatus);
+            panic_with_error!(&env, ContractError::DisputeNotOpen);
         }
         if buyer_share + seller_share != session.amount {
-            panic_with_error!(&env, ContractError::SharesMismatch);
+            panic_with_error!(&env, ContractError::InvalidSplit);
         }
         let (_after_fee, _fee) = apply_fee(&env, seller_share);
         session.status = SessionStatus::Resolved;


### PR DESCRIPTION
## Summary

Implements four issues:

**#940 — Financial validation errors**
- Adds `InvalidAmount` (400), `InsufficientBalance` (401), `FeeTooHigh` (402), `InvalidSplit` (403), `Overflow` (404) to the Soroban contract's `ContractError` enum.
- Renames the pre-existing `AmountMustBePositive`/`SharesMismatch`/`FeeTooHigh` variants to the new naming + numbering scheme and updates their call sites in `create_session` and `resolve_dispute`.

**#941 — Timeout and dispute errors**
- Adds `DisputeWindowNotElapsed` (500), `DisputeAlreadyOpen` (501), `DisputeNotOpen` (502), `ResolutionNotAllowed` (503) to `ContractError`.
- Wires `DisputeAlreadyOpen` into `open_dispute` and `DisputeNotOpen` into `resolve_dispute`, replacing the generic `InvalidStatus` panic where it maps exactly onto those checks.

**#1002 — User status enums**
- Adds `PENDING_VERIFICATION` to `UserStatus`, with a migration extending the Postgres enum type.
- JWT payload now carries `status`, resolved from a real (find-or-create) DB user record at login instead of a hardcoded roles stub — `sub` is now the user's DB id, consistent with how `UsersController` already used `req.user.sub`.
- `JwtAuthGuard` rejects requests where the token's status isn't `active`.
- `UsersService.updateStatus` enforces a status-transition allow-list (`deleted` is terminal, etc.) and is exposed via an admin-only `PATCH /user/admin/:id/status` endpoint.

**#1003 — Username / display name support**
- `username` is now unique at the DB level (30-char cap), with a `usernameChangedAt` column to track the 30-day change cooldown; migration adds the constraint and column.
- New `UpdateUsernameDto` validates alphanumeric + single underscore/dash separators, 3-30 chars, no leading/trailing/consecutive special characters.
- `GET /user/username/available?username=foo` and `PATCH /user/username` (cooldown + uniqueness enforced, change logged) added; `username` removed from the general `PATCH /user` DTO now that it has a dedicated endpoint.
- New user records default `displayName` from the wallet address prefix.
- New public `GET /profiles/:username` endpoint (`ProfilesController`), returning only active users' public-safe fields (no wallet/email/status).

## Test plan
- [ ] Not run in this environment (no Rust/Node toolchain available); verify `cargo test` on the contract and `nest build` / relevant unit tests on the backend before merging.

Closes #940
Closes #941
Closes #1002
Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)