### PR TITLE
DTO validation, pagination utility, profile completeness score, featured mentor flag

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,8 @@ import { AuthModule } from './auth/auth.module.js';
 import { AvailabilityModule } from './availability/availability.module.js';
 import { VerificationModule } from './verification/verification.module.js';
 import { PaginationModule } from './common/pagination/pagination.module.js';
+import { RedisModule } from './config/redis.module.js';
+import { MentorsModule } from './mentors/mentors.module.js';
 import typeOrmConfig from './config/typeorm.config.js';
 
 @Module({
@@ -16,11 +18,13 @@ import typeOrmConfig from './config/typeorm.config.js';
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRoot(typeOrmConfig),
     ThrottlerModule.forRoot([{ ttl: 60000, limit: 100 }]),
+    RedisModule.forRoot(),
     PaginationModule,
     UsersModule,
     AuthModule,
     AvailabilityModule,
     VerificationModule,
+    MentorsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { UsersModule } from './users/users.module.js';
 import { AuthModule } from './auth/auth.module.js';
 import { AvailabilityModule } from './availability/availability.module.js';
 import { VerificationModule } from './verification/verification.module.js';
+import { PaginationModule } from './common/pagination/pagination.module.js';
 import typeOrmConfig from './config/typeorm.config.js';
 
 @Module({
@@ -15,6 +16,7 @@ import typeOrmConfig from './config/typeorm.config.js';
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRoot(typeOrmConfig),
     ThrottlerModule.forRoot([{ ttl: 60000, limit: 100 }]),
+    PaginationModule,
     UsersModule,
     AuthModule,
     AvailabilityModule,

--- a/backend/src/auth/dto/wallet-login.dto.ts
+++ b/backend/src/auth/dto/wallet-login.dto.ts
@@ -1,4 +1,5 @@
-import { IsString, IsNotEmpty, Matches } from 'class-validator';
+import { IsString, IsNotEmpty } from 'class-validator';
+import { IsValidWalletAddress } from '../../common/validators/is-valid-wallet-address.validator.js';
 
 /**
  * #973: DTO for wallet-based login via signature verification.
@@ -6,7 +7,7 @@ import { IsString, IsNotEmpty, Matches } from 'class-validator';
 export class WalletLoginDto {
   @IsString()
   @IsNotEmpty()
-  @Matches(/^G[A-Z0-9]{55}$/, { message: 'Invalid Stellar public key format' })
+  @IsValidWalletAddress()
   walletAddress: string;
 
   @IsString()

--- a/backend/src/availability/dto/availability.dto.ts
+++ b/backend/src/availability/dto/availability.dto.ts
@@ -10,6 +10,8 @@ import {
   Max,
   Min,
 } from 'class-validator';
+import { IsValidTimezone } from '../../common/validators/is-valid-timezone.validator.js';
+import { IsValidAvailabilitySlot } from '../../common/validators/is-valid-availability-slot.validator.js';
 
 const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
 
@@ -27,10 +29,12 @@ export class CreateAvailabilitySlotDto {
 
   @IsString()
   @Matches(TIME_REGEX, { message: 'endTime must be HH:MM (24-hour)' })
+  @IsValidAvailabilitySlot()
   endTime: string;
 
   @IsString()
   @IsNotEmpty()
+  @IsValidTimezone()
   timezone: string;
 }
 
@@ -49,10 +53,12 @@ export class UpdateAvailabilitySlotDto {
   @IsOptional()
   @IsString()
   @Matches(TIME_REGEX, { message: 'endTime must be HH:MM (24-hour)' })
+  @IsValidAvailabilitySlot()
   endTime?: string;
 
   @IsOptional()
   @IsString()
+  @IsValidTimezone()
   timezone?: string;
 
   @IsOptional()

--- a/backend/src/common/dto/pagination-query.dto.ts
+++ b/backend/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,23 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+/**
+ * #1006/#1007: Reusable base DTO for offset/limit pagination query params.
+ * Extend this from any list-endpoint query DTO instead of redeclaring
+ * page/limit validation. The upper bound on `limit` is enforced by
+ * PaginationService (configurable, default 100) rather than here, so a
+ * single DTO works for endpoints with different max-limit policies.
+ */
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
+}

--- a/backend/src/common/pagination/index.ts
+++ b/backend/src/common/pagination/index.ts
@@ -1,0 +1,3 @@
+export * from './pagination.interface.js';
+export * from './pagination.service.js';
+export * from './pagination.module.js';

--- a/backend/src/common/pagination/pagination.interface.ts
+++ b/backend/src/common/pagination/pagination.interface.ts
@@ -1,0 +1,35 @@
+/**
+ * #1007: Standardized pagination response shapes shared by every
+ * list endpoint in the app.
+ */
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  meta: PaginationMeta;
+}
+
+export interface PaginationLinks {
+  first: string;
+  prev: string | null;
+  next: string | null;
+  last: string;
+}
+
+export interface CursorPaginationMeta {
+  limit: number;
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+export interface CursorPaginatedResponse<T> {
+  data: T[];
+  meta: CursorPaginationMeta;
+}

--- a/backend/src/common/pagination/pagination.module.ts
+++ b/backend/src/common/pagination/pagination.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { PaginationService } from './pagination.service.js';
+
+/**
+ * #1007: Global module so any feature module can inject PaginationService
+ * without re-declaring it as a provider.
+ */
+@Global()
+@Module({
+  providers: [PaginationService],
+  exports: [PaginationService],
+})
+export class PaginationModule {}

--- a/backend/src/common/pagination/pagination.service.ts
+++ b/backend/src/common/pagination/pagination.service.ts
@@ -1,0 +1,177 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import {
+  CursorPaginatedResponse,
+  PaginatedResponse,
+  PaginationLinks,
+} from './pagination.interface.js';
+
+export interface PaginateOptions {
+  /** Upper bound on `limit`, regardless of what the caller requests. */
+  maxLimit?: number;
+  defaultLimit?: number;
+}
+
+export interface CursorPaginateOptions {
+  cursor?: string;
+  limit?: number;
+  maxLimit?: number;
+  order?: 'ASC' | 'DESC';
+}
+
+const DEFAULT_MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 20;
+
+/**
+ * #1007: Reusable pagination helper so every list endpoint returns the same
+ * `{ data, meta }` shape instead of hand-rolling skip/take + counting.
+ */
+@Injectable()
+export class PaginationService {
+  /**
+   * Offset/limit pagination. Accepts either a TypeORM Repository (uses
+   * findAndCount) or a SelectQueryBuilder (uses getManyAndCount) so callers
+   * can add filters/joins/order before handing it off.
+   */
+  async paginate<T extends object>(
+    source: Repository<T> | SelectQueryBuilder<T>,
+    page?: number,
+    limit?: number,
+    options: PaginateOptions = {},
+  ): Promise<PaginatedResponse<T>> {
+    const { safePage, safeLimit } = this.normalize(page, limit, options);
+    const skip = (safePage - 1) * safeLimit;
+
+    let data: T[];
+    let total: number;
+
+    if (source instanceof Repository) {
+      [data, total] = await source.findAndCount({
+        skip,
+        take: safeLimit,
+      });
+    } else {
+      [data, total] = await source.clone().skip(skip).take(safeLimit).getManyAndCount();
+    }
+
+    const totalPages = total === 0 ? 0 : Math.ceil(total / safeLimit);
+
+    return {
+      data,
+      meta: {
+        page: safePage,
+        limit: safeLimit,
+        total,
+        totalPages,
+        hasNext: safePage < totalPages,
+        hasPrev: safePage > 1 && totalPages > 0,
+      },
+    };
+  }
+
+  /**
+   * Cursor-based pagination for large/high-throughput datasets where
+   * offset counting is too expensive. `cursorColumn` must be a strictly
+   * orderable, unique-enough column (e.g. a UUID primary key or timestamp).
+   */
+  async paginateByCursor<T extends object>(
+    qb: SelectQueryBuilder<T>,
+    cursorColumn: string,
+    options: CursorPaginateOptions = {},
+  ): Promise<CursorPaginatedResponse<T>> {
+    const maxLimit = options.maxLimit ?? DEFAULT_MAX_LIMIT;
+    const limit = Math.min(
+      Math.max(this.toPositiveInt(options.limit, DEFAULT_LIMIT), 1),
+      maxLimit,
+    );
+    const order = options.order ?? 'ASC';
+    const alias = qb.alias;
+
+    const query = qb
+      .clone()
+      .orderBy(`${alias}.${cursorColumn}`, order)
+      .take(limit + 1);
+
+    if (options.cursor) {
+      const cursorValue = this.decodeCursor(options.cursor);
+      query.andWhere(
+        `${alias}.${cursorColumn} ${order === 'ASC' ? '>' : '<'} :cursorValue`,
+        { cursorValue },
+      );
+    }
+
+    const rows = await query.getMany();
+    const hasNext = rows.length > limit;
+    const data = hasNext ? rows.slice(0, limit) : rows;
+    const lastRow = data[data.length - 1] as Record<string, unknown> | undefined;
+
+    return {
+      data,
+      meta: {
+        limit,
+        nextCursor:
+          hasNext && lastRow ? this.encodeCursor(lastRow[cursorColumn]) : null,
+        hasNext,
+      },
+    };
+  }
+
+  /** Builds first/prev/next/last links for a given base URL (query-string free). */
+  buildLinks(
+    baseUrl: string,
+    page: number,
+    limit: number,
+    totalPages: number,
+  ): PaginationLinks {
+    const urlFor = (targetPage: number): string => {
+      const url = new URL(baseUrl);
+      url.searchParams.set('page', String(targetPage));
+      url.searchParams.set('limit', String(limit));
+      return url.toString();
+    };
+
+    return {
+      first: urlFor(1),
+      prev: page > 1 ? urlFor(page - 1) : null,
+      next: totalPages > 0 && page < totalPages ? urlFor(page + 1) : null,
+      last: urlFor(Math.max(totalPages, 1)),
+    };
+  }
+
+  private normalize(
+    page: number | undefined,
+    limit: number | undefined,
+    options: PaginateOptions,
+  ): { safePage: number; safeLimit: number } {
+    const maxLimit = options.maxLimit ?? DEFAULT_MAX_LIMIT;
+    const defaultLimit = options.defaultLimit ?? DEFAULT_LIMIT;
+
+    const safePage = Math.max(this.toPositiveInt(page, 1), 1);
+    const safeLimit = Math.min(
+      Math.max(this.toPositiveInt(limit, defaultLimit), 1),
+      maxLimit,
+    );
+
+    return { safePage, safeLimit };
+  }
+
+  private toPositiveInt(value: number | undefined, fallback: number): number {
+    if (value === undefined || value === null) return fallback;
+    const parsed = Math.floor(Number(value));
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  private encodeCursor(value: unknown): string {
+    return Buffer.from(String(value), 'utf-8').toString('base64');
+  }
+
+  private decodeCursor(cursor: string): string {
+    try {
+      const decoded = Buffer.from(cursor, 'base64').toString('utf-8');
+      if (!decoded) throw new Error('empty cursor');
+      return decoded;
+    } catch {
+      throw new BadRequestException('Invalid pagination cursor');
+    }
+  }
+}

--- a/backend/src/common/pagination/pagination.service.ts
+++ b/backend/src/common/pagination/pagination.service.ts
@@ -51,7 +51,11 @@ export class PaginationService {
         take: safeLimit,
       });
     } else {
-      [data, total] = await source.clone().skip(skip).take(safeLimit).getManyAndCount();
+      [data, total] = await source
+        .clone()
+        .skip(skip)
+        .take(safeLimit)
+        .getManyAndCount();
     }
 
     const totalPages = total === 0 ? 0 : Math.ceil(total / safeLimit);
@@ -103,7 +107,8 @@ export class PaginationService {
     const rows = await query.getMany();
     const hasNext = rows.length > limit;
     const data = hasNext ? rows.slice(0, limit) : rows;
-    const lastRow = data[data.length - 1] as Record<string, unknown> | undefined;
+    const lastRow = data[data.length - 1] as
+      Record<string, unknown> | undefined;
 
     return {
       data,

--- a/backend/src/common/validators/index.ts
+++ b/backend/src/common/validators/index.ts
@@ -1,0 +1,4 @@
+export * from './is-valid-wallet-address.validator.js';
+export * from './is-valid-timezone.validator.js';
+export * from './is-after-date.validator.js';
+export * from './is-valid-availability-slot.validator.js';

--- a/backend/src/common/validators/is-after-date.validator.ts
+++ b/backend/src/common/validators/is-after-date.validator.ts
@@ -1,0 +1,52 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+/**
+ * #1006: Cross-field business-rule validator. Ensures the decorated property
+ * is chronologically after another property on the same DTO. Both values are
+ * optional — the check is skipped unless both are present, so it composes
+ * cleanly with @IsOptional() on either field.
+ */
+@ValidatorConstraint({ name: 'IsAfterDate', async: false })
+export class IsAfterDateConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    const [relatedPropertyName] = args.constraints as [string];
+    const relatedValue = (args.object as Record<string, unknown>)[
+      relatedPropertyName
+    ];
+
+    if (value === undefined || value === null) return true;
+    if (relatedValue === undefined || relatedValue === null) return true;
+
+    const current = new Date(value as string | number | Date);
+    const related = new Date(relatedValue as string | number | Date);
+    if (isNaN(current.getTime()) || isNaN(related.getTime())) return false;
+
+    return current.getTime() > related.getTime();
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const [relatedPropertyName] = args.constraints as [string];
+    return `${args.property} must be a date after ${relatedPropertyName}`;
+  }
+}
+
+export function IsAfterDate(
+  relatedPropertyName: string,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [relatedPropertyName],
+      validator: IsAfterDateConstraint,
+    });
+  };
+}

--- a/backend/src/common/validators/is-valid-availability-slot.validator.ts
+++ b/backend/src/common/validators/is-valid-availability-slot.validator.ts
@@ -1,0 +1,45 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/**
+ * #1006: Cross-field business-rule validator for availability slots.
+ * Decorate the `endTime` field with this; it reads the sibling `startTime`
+ * off the DTO instance and ensures both are well-formed "HH:MM" and that
+ * startTime precedes endTime. Skips the check when either side is absent so
+ * it composes with @IsOptional() on partial/update DTOs.
+ */
+@ValidatorConstraint({ name: 'IsValidAvailabilitySlot', async: false })
+export class IsValidAvailabilitySlotConstraint
+  implements ValidatorConstraintInterface
+{
+  validate(endTime: unknown, args: ValidationArguments): boolean {
+    const startTime = (args.object as Record<string, unknown>).startTime;
+    if (startTime === undefined || endTime === undefined) return true;
+    if (typeof startTime !== 'string' || typeof endTime !== 'string') return false;
+    if (!TIME_REGEX.test(startTime) || !TIME_REGEX.test(endTime)) return false;
+    return startTime < endTime;
+  }
+
+  defaultMessage(): string {
+    return 'startTime and endTime must be valid HH:MM times, with startTime before endTime';
+  }
+}
+
+export function IsValidAvailabilitySlot(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsValidAvailabilitySlotConstraint,
+    });
+  };
+}

--- a/backend/src/common/validators/is-valid-availability-slot.validator.ts
+++ b/backend/src/common/validators/is-valid-availability-slot.validator.ts
@@ -16,13 +16,12 @@ const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
  * it composes with @IsOptional() on partial/update DTOs.
  */
 @ValidatorConstraint({ name: 'IsValidAvailabilitySlot', async: false })
-export class IsValidAvailabilitySlotConstraint
-  implements ValidatorConstraintInterface
-{
+export class IsValidAvailabilitySlotConstraint implements ValidatorConstraintInterface {
   validate(endTime: unknown, args: ValidationArguments): boolean {
     const startTime = (args.object as Record<string, unknown>).startTime;
     if (startTime === undefined || endTime === undefined) return true;
-    if (typeof startTime !== 'string' || typeof endTime !== 'string') return false;
+    if (typeof startTime !== 'string' || typeof endTime !== 'string')
+      return false;
     if (!TIME_REGEX.test(startTime) || !TIME_REGEX.test(endTime)) return false;
     return startTime < endTime;
   }

--- a/backend/src/common/validators/is-valid-timezone.validator.ts
+++ b/backend/src/common/validators/is-valid-timezone.validator.ts
@@ -1,0 +1,34 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { isValidIanaTimezone } from '../utils/timezone.utils.js';
+
+/**
+ * #1006: Business-rule validator for IANA timezone identifiers
+ * (e.g. "America/New_York", "UTC").
+ */
+@ValidatorConstraint({ name: 'IsValidTimezone', async: false })
+export class IsValidTimezoneConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return typeof value === 'string' && isValidIanaTimezone(value);
+  }
+
+  defaultMessage(): string {
+    return 'timezone must be a valid IANA timezone identifier (e.g. "America/New_York")';
+  }
+}
+
+export function IsValidTimezone(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsValidTimezoneConstraint,
+    });
+  };
+}

--- a/backend/src/common/validators/is-valid-wallet-address.validator.ts
+++ b/backend/src/common/validators/is-valid-wallet-address.validator.ts
@@ -1,0 +1,37 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { tryNormalizeWalletAddress } from '../utils/wallet.utils.js';
+
+/**
+ * #1006: Business-rule validator for Stellar public key wallet addresses.
+ * Reuses the same normalization/format rules as the auth layer so DTO-level
+ * validation and service-level normalization never drift apart.
+ */
+@ValidatorConstraint({ name: 'IsValidWalletAddress', async: false })
+export class IsValidWalletAddressConstraint
+  implements ValidatorConstraintInterface
+{
+  validate(value: unknown): boolean {
+    return typeof value === 'string' && tryNormalizeWalletAddress(value) !== null;
+  }
+
+  defaultMessage(): string {
+    return 'walletAddress must be a valid Stellar public key (G + 55 base32 characters)';
+  }
+}
+
+export function IsValidWalletAddress(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsValidWalletAddressConstraint,
+    });
+  };
+}

--- a/backend/src/common/validators/is-valid-wallet-address.validator.ts
+++ b/backend/src/common/validators/is-valid-wallet-address.validator.ts
@@ -12,11 +12,11 @@ import { tryNormalizeWalletAddress } from '../utils/wallet.utils.js';
  * validation and service-level normalization never drift apart.
  */
 @ValidatorConstraint({ name: 'IsValidWalletAddress', async: false })
-export class IsValidWalletAddressConstraint
-  implements ValidatorConstraintInterface
-{
+export class IsValidWalletAddressConstraint implements ValidatorConstraintInterface {
   validate(value: unknown): boolean {
-    return typeof value === 'string' && tryNormalizeWalletAddress(value) !== null;
+    return (
+      typeof value === 'string' && tryNormalizeWalletAddress(value) !== null
+    );
   }
 
   defaultMessage(): string {

--- a/backend/src/database/migrations/1722400000000-AddAvatarUrlToUsers.ts
+++ b/backend/src/database/migrations/1722400000000-AddAvatarUrlToUsers.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * #1004: Adds an avatar URL to the users table so profile completeness
+ * scoring can check for it (required field for mentor profiles).
+ */
+export class AddAvatarUrlToUsers1722400000000 implements MigrationInterface {
+  name = 'AddAvatarUrlToUsers1722400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users" ADD COLUMN "avatarUrl" varchar(2048)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users" DROP COLUMN "avatarUrl"
+    `);
+  }
+}

--- a/backend/src/database/migrations/1722410000000-AddFeaturedFieldsToMentorProfiles.ts
+++ b/backend/src/database/migrations/1722410000000-AddFeaturedFieldsToMentorProfiles.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * #1005: Adds featured-mentor fields to mentor_profiles, plus the
+ * composite index used by the public "featured mentors" listing.
+ */
+export class AddFeaturedFieldsToMentorProfiles1722410000000 implements MigrationInterface {
+  name = 'AddFeaturedFieldsToMentorProfiles1722410000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "mentor_profiles"
+        ADD COLUMN "isFeatured" boolean NOT NULL DEFAULT false,
+        ADD COLUMN "featuredAt" TIMESTAMP,
+        ADD COLUMN "featuredExpiresAt" TIMESTAMP,
+        ADD COLUMN "featuredOrder" integer NOT NULL DEFAULT 0
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_mentor_profiles_isFeatured" ON "mentor_profiles" ("isFeatured")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_mentor_profiles_featuredOrder" ON "mentor_profiles" ("featuredOrder")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_mentor_profiles_isFeatured_featuredOrder"
+        ON "mentor_profiles" ("isFeatured", "featuredOrder")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_mentor_profiles_isFeatured_featuredOrder"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_mentor_profiles_featuredOrder"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_mentor_profiles_isFeatured"`,
+    );
+    await queryRunner.query(`
+      ALTER TABLE "mentor_profiles"
+        DROP COLUMN "featuredOrder",
+        DROP COLUMN "featuredExpiresAt",
+        DROP COLUMN "featuredAt",
+        DROP COLUMN "isFeatured"
+    `);
+  }
+}

--- a/backend/src/database/migrations/1722420000000-CreateMentorFeatureAuditLogs.ts
+++ b/backend/src/database/migrations/1722420000000-CreateMentorFeatureAuditLogs.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * #1005: Audit log table for feature/unfeature admin actions.
+ */
+export class CreateMentorFeatureAuditLogs1722420000000 implements MigrationInterface {
+  name = 'CreateMentorFeatureAuditLogs1722420000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "mentor_feature_audit_action_enum" AS ENUM (
+        'featured', 'unfeatured', 'order_updated', 'auto_expired'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "mentor_feature_audit_logs" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "mentorId" uuid NOT NULL,
+        "adminId" uuid,
+        "action" "mentor_feature_audit_action_enum" NOT NULL,
+        "metadata" jsonb NOT NULL DEFAULT '{}',
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_mentor_feature_audit_logs" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_mentor_feature_audit_logs_mentor" FOREIGN KEY ("mentorId") REFERENCES "users"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_mentor_feature_audit_logs_admin" FOREIGN KEY ("adminId") REFERENCES "users"("id") ON DELETE SET NULL
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_mentor_feature_audit_logs_mentorId" ON "mentor_feature_audit_logs" ("mentorId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_mentor_feature_audit_logs_adminId" ON "mentor_feature_audit_logs" ("adminId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "mentor_feature_audit_logs"`);
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "mentor_feature_audit_action_enum"`,
+    );
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,34 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+import { ValidationError } from 'class-validator';
 import { AppModule } from './app.module.js';
+
+/**
+ * #1006: Flattens class-validator's nested ValidationError tree into a
+ * simple { field, code, message }[] shape. `code` is the class-validator
+ * constraint name (e.g. "isEmail"), kept stable/machine-readable so clients
+ * can map it to a localized string; `message` is the English fallback.
+ */
+function flattenValidationErrors(
+  errors: ValidationError[],
+  parentPath = '',
+): { field: string; code: string; message: string }[] {
+  return errors.flatMap((error) => {
+    const field = parentPath
+      ? `${parentPath}.${error.property}`
+      : error.property;
+
+    const ownMessages = Object.entries(error.constraints ?? {}).map(
+      ([code, message]) => ({ field, code, message }),
+    );
+
+    const childMessages = error.children?.length
+      ? flattenValidationErrors(error.children, field)
+      : [];
+
+    return [...ownMessages, ...childMessages];
+  });
+}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -11,6 +39,12 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
       transform: true,
       transformOptions: { enableImplicitConversion: true },
+      exceptionFactory: (errors: ValidationError[]) =>
+        new BadRequestException({
+          error: 'VALIDATION_ERROR',
+          message: 'Request validation failed',
+          errors: flattenValidationErrors(errors),
+        }),
     }),
   );
 

--- a/backend/src/mentors/dto/mentor-feature.dto.ts
+++ b/backend/src/mentors/dto/mentor-feature.dto.ts
@@ -1,0 +1,9 @@
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class FeatureMentorDto {
+  /** Optional manual sort position; appended to the end if omitted. */
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  featuredOrder?: number;
+}

--- a/backend/src/mentors/entities/mentor-feature-audit-log.entity.ts
+++ b/backend/src/mentors/entities/mentor-feature-audit-log.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity.js';
+
+export enum MentorFeatureAuditAction {
+  FEATURED = 'featured',
+  UNFEATURED = 'unfeatured',
+  ORDER_UPDATED = 'order_updated',
+  AUTO_EXPIRED = 'auto_expired',
+}
+
+/**
+ * #1005: Immutable audit log for every featured-mentor state-change.
+ */
+@Entity('mentor_feature_audit_logs')
+@Index(['mentorId'])
+@Index(['adminId'])
+export class MentorFeatureAuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  mentorId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'mentorId' })
+  mentor: User;
+
+  /** Null for system-initiated actions (e.g. auto_expired). */
+  @Column({ type: 'uuid', nullable: true })
+  adminId: string | null;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'adminId' })
+  admin: User | null;
+
+  @Column({
+    type: 'enum',
+    enum: MentorFeatureAuditAction,
+  })
+  action: MentorFeatureAuditAction;
+
+  @Column({ type: 'jsonb', default: () => "'{}'" })
+  metadata: Record<string, unknown>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/mentors/mentors.controller.ts
+++ b/backend/src/mentors/mentors.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { MentorsService } from './mentors.service.js';
+import { FeatureMentorDto } from './dto/mentor-feature.dto.js';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto.js';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard.js';
+import { RolesGuard } from '../auth/guards/roles.guard.js';
+import { Roles } from '../auth/decorators/roles.decorator.js';
+import { AuthRole } from '../common/enums/auth-role.enum.js';
+
+/**
+ * #1005: Featured mentor endpoints.
+ *
+ * Public:
+ *   GET /mentors/featured                     — paginated list of active featured mentors
+ *
+ * Admin-only:
+ *   POST   /admin/mentors/:mentorId/feature    — feature a mentor
+ *   DELETE /admin/mentors/:mentorId/unfeature  — unfeature a mentor
+ */
+@Controller()
+export class MentorsController {
+  constructor(private readonly mentorsService: MentorsService) {}
+
+  @Get('mentors/featured')
+  getFeaturedMentors(@Query() query: PaginationQueryDto) {
+    return this.mentorsService.getFeaturedMentors(query.page, query.limit);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(AuthRole.ADMIN)
+  @Post('admin/mentors/:mentorId/feature')
+  featureMentor(
+    @Param('mentorId', ParseUUIDPipe) mentorId: string,
+    @Request() req: { user: { sub: string } },
+    @Body() dto: FeatureMentorDto,
+  ) {
+    return this.mentorsService.featureMentor(mentorId, req.user.sub, dto);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(AuthRole.ADMIN)
+  @Delete('admin/mentors/:mentorId/unfeature')
+  unfeatureMentor(
+    @Param('mentorId', ParseUUIDPipe) mentorId: string,
+    @Request() req: { user: { sub: string } },
+  ) {
+    return this.mentorsService.unfeatureMentor(mentorId, req.user.sub);
+  }
+}

--- a/backend/src/mentors/mentors.module.ts
+++ b/backend/src/mentors/mentors.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MentorProfile } from '../users/entities/mentor-profile.entity.js';
+import { MentorFeatureAuditLog } from './entities/mentor-feature-audit-log.entity.js';
+import { MentorsService } from './mentors.service.js';
+import { MentorsController } from './mentors.controller.js';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MentorProfile, MentorFeatureAuditLog])],
+  controllers: [MentorsController],
+  providers: [MentorsService],
+  exports: [MentorsService],
+})
+export class MentorsModule {}

--- a/backend/src/mentors/mentors.service.ts
+++ b/backend/src/mentors/mentors.service.ts
@@ -1,0 +1,172 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { MentorProfile } from '../users/entities/mentor-profile.entity.js';
+import {
+  MentorFeatureAuditAction,
+  MentorFeatureAuditLog,
+} from './entities/mentor-feature-audit-log.entity.js';
+import { FeatureMentorDto } from './dto/mentor-feature.dto.js';
+import {
+  PaginatedResponse,
+  PaginationService,
+} from '../common/pagination/index.js';
+
+const DEFAULT_MAX_FEATURED = 10;
+const DEFAULT_FEATURED_DURATION_DAYS = 30;
+
+/**
+ * #1005: Admin-curated "featured mentor" placement, shown on the homepage
+ * and discovery sections. Featured status auto-expires (lazily, on read)
+ * after a configurable duration.
+ */
+@Injectable()
+export class MentorsService {
+  private readonly maxFeatured: number;
+  private readonly featuredDurationDays: number;
+
+  constructor(
+    @InjectRepository(MentorProfile)
+    private readonly mentorProfileRepo: Repository<MentorProfile>,
+    @InjectRepository(MentorFeatureAuditLog)
+    private readonly auditRepo: Repository<MentorFeatureAuditLog>,
+    private readonly paginationService: PaginationService,
+    private readonly configService: ConfigService,
+  ) {
+    this.maxFeatured = this.configService.get<number>(
+      'FEATURED_MENTORS_MAX',
+      DEFAULT_MAX_FEATURED,
+    );
+    this.featuredDurationDays = this.configService.get<number>(
+      'FEATURED_MENTORS_DURATION_DAYS',
+      DEFAULT_FEATURED_DURATION_DAYS,
+    );
+  }
+
+  async featureMentor(
+    mentorId: string,
+    adminId: string,
+    dto: FeatureMentorDto,
+  ): Promise<MentorProfile> {
+    const profile = await this.mentorProfileRepo.findOne({
+      where: { userId: mentorId },
+    });
+    if (!profile) {
+      throw new NotFoundException('Mentor profile not found');
+    }
+
+    if (!profile.isFeatured) {
+      const activeCount = await this.countActiveFeatured();
+      if (activeCount >= this.maxFeatured) {
+        throw new BadRequestException(
+          `Cannot feature more than ${this.maxFeatured} mentors at once`,
+        );
+      }
+    }
+
+    const now = new Date();
+    const expiresAt = new Date(now);
+    expiresAt.setUTCDate(expiresAt.getUTCDate() + this.featuredDurationDays);
+
+    profile.isFeatured = true;
+    profile.featuredAt = now;
+    profile.featuredExpiresAt = expiresAt;
+    profile.featuredOrder =
+      dto.featuredOrder ?? (await this.nextFeaturedOrder());
+
+    const saved = await this.mentorProfileRepo.save(profile);
+
+    await this.writeAudit(
+      mentorId,
+      adminId,
+      MentorFeatureAuditAction.FEATURED,
+      {
+        featuredOrder: saved.featuredOrder,
+        featuredExpiresAt: saved.featuredExpiresAt,
+      },
+    );
+
+    return saved;
+  }
+
+  async unfeatureMentor(
+    mentorId: string,
+    adminId: string,
+  ): Promise<MentorProfile> {
+    const profile = await this.mentorProfileRepo.findOne({
+      where: { userId: mentorId },
+    });
+    if (!profile) {
+      throw new NotFoundException('Mentor profile not found');
+    }
+    if (!profile.isFeatured) {
+      throw new BadRequestException('Mentor is not currently featured');
+    }
+
+    profile.isFeatured = false;
+    profile.featuredAt = null;
+    profile.featuredExpiresAt = null;
+    profile.featuredOrder = 0;
+
+    const saved = await this.mentorProfileRepo.save(profile);
+
+    await this.writeAudit(
+      mentorId,
+      adminId,
+      MentorFeatureAuditAction.UNFEATURED,
+      {},
+    );
+
+    return saved;
+  }
+
+  async getFeaturedMentors(
+    page?: number,
+    limit?: number,
+  ): Promise<PaginatedResponse<MentorProfile>> {
+    const qb = this.activeFeaturedQuery()
+      .leftJoinAndSelect('profile.user', 'user')
+      .orderBy('profile.featuredOrder', 'ASC');
+
+    return this.paginationService.paginate(qb, page, limit);
+  }
+
+  private activeFeaturedQuery() {
+    return this.mentorProfileRepo
+      .createQueryBuilder('profile')
+      .where('profile.isFeatured = true')
+      .andWhere(
+        '(profile.featuredExpiresAt IS NULL OR profile.featuredExpiresAt > :now)',
+        { now: new Date() },
+      );
+  }
+
+  private async countActiveFeatured(): Promise<number> {
+    return this.activeFeaturedQuery().getCount();
+  }
+
+  private async nextFeaturedOrder(): Promise<number> {
+    const { max } = (await this.mentorProfileRepo
+      .createQueryBuilder('profile')
+      .select('MAX(profile.featuredOrder)', 'max')
+      .where('profile.isFeatured = true')
+      .getRawOne<{ max: string | null }>()) ?? { max: null };
+
+    return (Number(max) || 0) + 1;
+  }
+
+  private async writeAudit(
+    mentorId: string,
+    adminId: string | null,
+    action: MentorFeatureAuditAction,
+    metadata: Record<string, unknown>,
+  ): Promise<void> {
+    const log = this.auditRepo.create({ mentorId, adminId, action, metadata });
+    await this.auditRepo.save(log);
+  }
+}

--- a/backend/src/users/dto/create-mentor-profile.dto.ts
+++ b/backend/src/users/dto/create-mentor-profile.dto.ts
@@ -11,6 +11,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { IsAfterDate } from '../../common/validators/is-after-date.validator.js';
 
 export class EducationDto {
   @IsString()
@@ -41,6 +42,9 @@ export class CertificationDto {
 
   @IsString()
   @IsOptional()
+  @IsAfterDate('issueDate', {
+    message: 'expirationDate must be after issueDate',
+  })
   expirationDate?: string;
 }
 

--- a/backend/src/users/dto/profile-completeness-response.dto.ts
+++ b/backend/src/users/dto/profile-completeness-response.dto.ts
@@ -1,0 +1,19 @@
+export interface MissingField {
+  field: string;
+  description: string;
+}
+
+/**
+ * #1004: Response shape for GET /user/profile/completeness.
+ * `score` can exceed 100 (up to 110) when optional-field bonus applies.
+ */
+export class ProfileCompletenessResponseDto {
+  score: number;
+  profileType: 'mentor' | 'mentee';
+  missingFields: MissingField[];
+  suggestions: string[];
+}
+
+export interface UserCompletenessSummary extends ProfileCompletenessResponseDto {
+  userId: string;
+}

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,4 +1,10 @@
-import { IsEmail, IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  IsEmail,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
 
 export class UpdateUserDto {
   @IsOptional()
@@ -15,4 +21,9 @@ export class UpdateUserDto {
   @IsEmail()
   @MaxLength(255)
   email?: string;
+
+  @IsOptional()
+  @IsUrl()
+  @MaxLength(2048)
+  avatarUrl?: string;
 }

--- a/backend/src/users/dto/user-query.dto.ts
+++ b/backend/src/users/dto/user-query.dto.ts
@@ -1,22 +1,9 @@
-import { Type } from 'class-transformer';
-import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { IsEnum, IsOptional } from 'class-validator';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto.js';
 import { UserStatus } from '../enums/user-status.enum.js';
 
-export class UserQueryDto {
+export class UserQueryDto extends PaginationQueryDto {
   @IsOptional()
   @IsEnum(UserStatus)
   status?: UserStatus;
-
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  page?: number = 1;
-
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  @Max(100)
-  limit?: number = 20;
 }

--- a/backend/src/users/dto/user-response.dto.ts
+++ b/backend/src/users/dto/user-response.dto.ts
@@ -8,10 +8,12 @@ export class UserResponseDto {
   username: string | null;
   displayName: string | null;
   email: string | null;
+  avatarUrl: string | null;
   status: UserStatus;
   roles: AuthRole[];
   createdAt: Date;
   updatedAt: Date;
+  completenessScore?: number;
 
   static fromEntity(user: User): UserResponseDto {
     const dto = new UserResponseDto();
@@ -20,6 +22,7 @@ export class UserResponseDto {
     dto.username = user.username ?? null;
     dto.displayName = user.displayName ?? null;
     dto.email = user.email ?? null;
+    dto.avatarUrl = user.avatarUrl ?? null;
     dto.status = user.status;
     dto.roles = (user.roles ?? []).map((role) => role.name);
     dto.createdAt = user.createdAt;

--- a/backend/src/users/entities/mentor-profile.entity.ts
+++ b/backend/src/users/entities/mentor-profile.entity.ts
@@ -11,6 +11,7 @@ import {
 import { User } from './user.entity.js';
 
 @Entity('mentor_profiles')
+@Index(['isFeatured', 'featuredOrder'])
 export class MentorProfile {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -72,6 +73,20 @@ export class MentorProfile {
 
   @Column({ type: 'int', default: 1 })
   profileVersion: number;
+
+  @Index()
+  @Column({ type: 'boolean', default: false })
+  isFeatured: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  featuredAt: Date | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  featuredExpiresAt: Date | null;
+
+  @Index()
+  @Column({ type: 'int', default: 0 })
+  featuredOrder: number;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -29,6 +29,9 @@ export class User {
   @Column({ type: 'varchar', nullable: true })
   displayName: string;
 
+  @Column({ type: 'varchar', length: 2048, nullable: true })
+  avatarUrl: string | null;
+
   @Column({
     type: 'enum',
     enum: UserStatus,

--- a/backend/src/users/profile-completeness.service.ts
+++ b/backend/src/users/profile-completeness.service.ts
@@ -1,0 +1,256 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './entities/user.entity.js';
+import { MentorProfile } from './entities/mentor-profile.entity.js';
+import { MenteeProfile } from './entities/mentee-profile.entity.js';
+import { PortfolioLink } from './entities/portfolio-link.entity.js';
+import { AvailabilityService } from '../availability/availability.service.js';
+import { RedisService } from '../config/redis.module.js';
+import { PaginationService } from '../common/pagination/index.js';
+import {
+  MissingField,
+  ProfileCompletenessResponseDto,
+  UserCompletenessSummary,
+} from './dto/profile-completeness-response.dto.js';
+
+const CACHE_TTL_SECONDS = 300;
+const LOW_SCORE_THRESHOLD = 80;
+const MAX_BONUS_PERCENT = 10;
+
+interface FieldCheck {
+  field: string;
+  description: string;
+  filled: boolean;
+}
+
+/**
+ * #1004: Computes a dynamic profile-completion score (0-110) per profile
+ * type, with a short-lived cache to avoid recomputing on every request.
+ */
+@Injectable()
+export class ProfileCompletenessService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(MentorProfile)
+    private readonly mentorProfileRepo: Repository<MentorProfile>,
+    @InjectRepository(MenteeProfile)
+    private readonly menteeProfileRepo: Repository<MenteeProfile>,
+    @InjectRepository(PortfolioLink)
+    private readonly portfolioLinkRepo: Repository<PortfolioLink>,
+    private readonly availabilityService: AvailabilityService,
+    private readonly redisService: RedisService,
+    private readonly paginationService: PaginationService,
+  ) {}
+
+  async getCompleteness(
+    userId: string,
+  ): Promise<ProfileCompletenessResponseDto> {
+    const cacheKey = this.cacheKey(userId);
+    const cached = await this.redisService.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached) as ProfileCompletenessResponseDto;
+    }
+
+    const result = await this.compute(userId);
+    await this.redisService.set(
+      cacheKey,
+      JSON.stringify(result),
+      CACHE_TTL_SECONDS,
+    );
+    return result;
+  }
+
+  /** Invalidate the cached score, e.g. after a profile update. */
+  async invalidate(userId: string): Promise<void> {
+    await this.redisService.del(this.cacheKey(userId));
+  }
+
+  /** Admin view: paginated completeness scores across all users with a profile. */
+  async getAllCompletenessScores(
+    page?: number,
+    limit?: number,
+  ): Promise<{ data: UserCompletenessSummary[]; meta: unknown }> {
+    const qb = this.userRepo
+      .createQueryBuilder('user')
+      .leftJoin('user.mentorProfile', 'mentorProfile')
+      .leftJoin('user.menteeProfile', 'menteeProfile')
+      .where('mentorProfile.id IS NOT NULL OR menteeProfile.id IS NOT NULL')
+      .orderBy('user.createdAt', 'DESC');
+
+    const paginated = await this.paginationService.paginate(qb, page, limit);
+
+    const data = await Promise.all(
+      paginated.data.map(async (user) => ({
+        userId: user.id,
+        ...(await this.getCompleteness(user.id)),
+      })),
+    );
+
+    return { data, meta: paginated.meta };
+  }
+
+  private cacheKey(userId: string): string {
+    return `profile-completeness:${userId}`;
+  }
+
+  private async compute(
+    userId: string,
+  ): Promise<ProfileCompletenessResponseDto> {
+    const [user, mentorProfile, menteeProfile] = await Promise.all([
+      this.userRepo.findOne({ where: { id: userId } }),
+      this.mentorProfileRepo.findOne({ where: { userId } }),
+      this.menteeProfileRepo.findOne({ where: { userId } }),
+    ]);
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    if (mentorProfile) {
+      return this.computeMentorCompleteness(user, mentorProfile);
+    }
+    if (menteeProfile) {
+      return this.computeMenteeCompleteness(menteeProfile);
+    }
+
+    throw new NotFoundException(
+      'No mentor or mentee profile found for this user',
+    );
+  }
+
+  private async computeMentorCompleteness(
+    user: User,
+    profile: MentorProfile,
+  ): Promise<ProfileCompletenessResponseDto> {
+    const [slots, portfolioLinksCount] = await Promise.all([
+      this.availabilityService.getSlots(user.id),
+      this.portfolioLinkRepo.count({ where: { userId: user.id } }),
+    ]);
+
+    const required: FieldCheck[] = [
+      {
+        field: 'bio',
+        description: 'Add a short bio describing your mentoring background',
+        filled: !!profile.bio,
+      },
+      {
+        field: 'skills',
+        description: 'List at least one skill you can mentor in',
+        filled: (profile.skills?.length ?? 0) > 0,
+      },
+      {
+        field: 'hourlyRate',
+        description: 'Set your hourly rate',
+        filled: Number(profile.hourlyRate) > 0,
+      },
+      {
+        field: 'expertiseAreas',
+        description: 'Add at least one area of expertise',
+        filled: (profile.expertiseAreas?.length ?? 0) > 0,
+      },
+      {
+        field: 'avatar',
+        description: 'Upload a profile photo',
+        filled: !!user.avatarUrl,
+      },
+      {
+        field: 'availabilitySlots',
+        description:
+          'Add at least one availability slot so mentees can book you',
+        filled: slots.length > 0,
+      },
+    ];
+
+    const optional: FieldCheck[] = [
+      {
+        field: 'portfolioLinks',
+        description:
+          'Add a portfolio link (GitHub, LinkedIn, personal site, etc.)',
+        filled: portfolioLinksCount > 0,
+      },
+      {
+        field: 'education',
+        description: 'Add your education history',
+        filled: (profile.education?.length ?? 0) > 0,
+      },
+      {
+        field: 'certifications',
+        description: 'Add any relevant certifications',
+        filled: (profile.certifications?.length ?? 0) > 0,
+      },
+    ];
+
+    return this.buildResponse('mentor', required, optional);
+  }
+
+  private computeMenteeCompleteness(
+    profile: MenteeProfile,
+  ): ProfileCompletenessResponseDto {
+    const required: FieldCheck[] = [
+      {
+        field: 'learningGoals',
+        description: 'Add at least one learning goal',
+        filled: (profile.learningGoals?.length ?? 0) > 0,
+      },
+      {
+        field: 'currentSkillLevel',
+        description: 'Set your current skill level',
+        filled: !!profile.currentSkillLevel,
+      },
+      {
+        field: 'areasOfInterest',
+        description: 'Add at least one area of interest',
+        filled: (profile.areasOfInterest?.length ?? 0) > 0,
+      },
+    ];
+
+    const optional: FieldCheck[] = [
+      {
+        field: 'portfolioLinks',
+        description: 'Add a portfolio link to showcase your work',
+        filled: (profile.portfolioLinks?.length ?? 0) > 0,
+      },
+      {
+        field: 'professionalBackground',
+        description: 'Describe your professional background',
+        filled: !!profile.professionalBackground,
+      },
+      {
+        field: 'jobTitle',
+        description: 'Add your current job title',
+        filled: !!profile.jobTitle,
+      },
+    ];
+
+    return this.buildResponse('mentee', required, optional);
+  }
+
+  private buildResponse(
+    profileType: 'mentor' | 'mentee',
+    required: FieldCheck[],
+    optional: FieldCheck[],
+  ): ProfileCompletenessResponseDto {
+    const filledRequired = required.filter((f) => f.filled).length;
+    const baseScore = Math.round((filledRequired / required.length) * 100);
+
+    const filledOptional = optional.filter((f) => f.filled).length;
+    const bonus =
+      optional.length > 0
+        ? Math.round((filledOptional / optional.length) * MAX_BONUS_PERCENT)
+        : 0;
+
+    const score = Math.min(baseScore + bonus, 100 + MAX_BONUS_PERCENT);
+
+    const missingFields: MissingField[] = required
+      .filter((f) => !f.filled)
+      .map(({ field, description }) => ({ field, description }));
+
+    const suggestions =
+      baseScore < LOW_SCORE_THRESHOLD
+        ? missingFields.map((f) => `Complete "${f.field}": ${f.description}`)
+        : [];
+
+    return { score, profileType, missingFields, suggestions };
+  }
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -14,12 +14,14 @@ import {
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { UsersService } from './users.service.js';
+import { ProfileCompletenessService } from './profile-completeness.service.js';
 import { CreateProfileDto } from './dto/create-profile.dto.js';
 import { UpdateMentorProfileDto } from './dto/update-mentor-profile.dto.js';
 import { UpdateMenteeProfileDto } from './dto/update-mentee-profile.dto.js';
 import { UpdateUserDto } from './dto/update-user.dto.js';
 import { UserQueryDto } from './dto/user-query.dto.js';
 import { UserResponseDto } from './dto/user-response.dto.js';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto.js';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard.js';
 import { RolesGuard } from '../auth/guards/roles.guard.js';
 import { Roles } from '../auth/decorators/roles.decorator.js';
@@ -29,14 +31,27 @@ import { AuthRole } from '../common/enums/auth-role.enum.js';
 @Controller('user')
 @UseGuards(JwtAuthGuard)
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly profileCompletenessService: ProfileCompletenessService,
+  ) {}
 
   @Get()
   async getMe(
     @Req() req: Request & { user: JwtAccessTokenPayload },
   ): Promise<UserResponseDto> {
     const user = await this.usersService.findById(req.user.sub);
-    return UserResponseDto.fromEntity(user);
+    const dto = UserResponseDto.fromEntity(user);
+
+    try {
+      const completeness =
+        await this.profileCompletenessService.getCompleteness(user.id);
+      dto.completenessScore = completeness.score;
+    } catch {
+      // No mentor/mentee profile created yet — omit the score.
+    }
+
+    return dto;
   }
 
   @Patch()
@@ -45,6 +60,7 @@ export class UsersController {
     @Req() req: Request & { user: JwtAccessTokenPayload },
   ): Promise<UserResponseDto> {
     const user = await this.usersService.updateUser(req.user.sub, dto);
+    await this.profileCompletenessService.invalidate(req.user.sub);
     return UserResponseDto.fromEntity(user);
   }
 
@@ -68,6 +84,16 @@ export class UsersController {
     };
   }
 
+  @Get('admin/completeness')
+  @UseGuards(RolesGuard)
+  @Roles(AuthRole.ADMIN)
+  async getAllCompletenessScores(@Query() query: PaginationQueryDto) {
+    return this.profileCompletenessService.getAllCompletenessScores(
+      query.page,
+      query.limit,
+    );
+  }
+
   @Post('profile')
   @HttpCode(HttpStatus.CREATED)
   async createProfile(
@@ -76,13 +102,19 @@ export class UsersController {
   ) {
     const userId = req.user.sub;
 
-    if (dto.profileType === 'mentor') {
-      return this.usersService.createMentorProfile(
-        userId,
-        dto.mentorData ?? {},
-      );
-    }
-    return this.usersService.createMenteeProfile(userId, dto.menteeData ?? {});
+    const profile =
+      dto.profileType === 'mentor'
+        ? await this.usersService.createMentorProfile(
+            userId,
+            dto.mentorData ?? {},
+          )
+        : await this.usersService.createMenteeProfile(
+            userId,
+            dto.menteeData ?? {},
+          );
+
+    await this.profileCompletenessService.invalidate(userId);
+    return profile;
   }
 
   @Patch('profile/:type')
@@ -96,22 +128,33 @@ export class UsersController {
     const requesterRoles = req.user.roles ?? [];
 
     if (type === 'mentor') {
-      return this.usersService.updateMentorProfile(
+      const profile = await this.usersService.updateMentorProfile(
         userId,
         userId,
         requesterRoles,
         dto as UpdateMentorProfileDto,
       );
+      await this.profileCompletenessService.invalidate(userId);
+      return profile;
     }
     if (type === 'mentee') {
-      return this.usersService.updateMenteeProfile(
+      const profile = await this.usersService.updateMenteeProfile(
         userId,
         userId,
         requesterRoles,
         dto as UpdateMenteeProfileDto,
       );
+      await this.profileCompletenessService.invalidate(userId);
+      return profile;
     }
     return { message: 'Invalid profile type. Must be "mentor" or "mentee".' };
+  }
+
+  @Get('profile/completeness')
+  async getMyCompleteness(
+    @Req() req: Request & { user: JwtAccessTokenPayload },
+  ) {
+    return this.profileCompletenessService.getCompleteness(req.user.sub);
   }
 
   @Get('profile/:type')

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -63,8 +63,8 @@ export class UsersController {
   async listUsers(@Query() query: UserQueryDto) {
     const result = await this.usersService.findAll(query);
     return {
-      ...result,
       data: result.data.map((user) => UserResponseDto.fromEntity(user)),
+      meta: result.meta,
     };
   }
 

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -8,12 +8,21 @@ import { User } from './entities/user.entity.js';
 import { Role } from './entities/role.entity.js';
 import { MentorProfile } from './entities/mentor-profile.entity.js';
 import { MenteeProfile } from './entities/mentee-profile.entity.js';
+import { PortfolioLink } from './entities/portfolio-link.entity.js';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard.js';
 import { RolesGuard } from '../auth/guards/roles.guard.js';
+import { AvailabilityModule } from '../availability/availability.module.js';
+import { ProfileCompletenessService } from './profile-completeness.service.js';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Role, MentorProfile, MenteeProfile]),
+    TypeOrmModule.forFeature([
+      User,
+      Role,
+      MentorProfile,
+      MenteeProfile,
+      PortfolioLink,
+    ]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -23,9 +32,15 @@ import { RolesGuard } from '../auth/guards/roles.guard.js';
       }),
     }),
     ConfigModule,
+    AvailabilityModule,
   ],
   controllers: [UsersController],
-  providers: [UsersService, JwtAuthGuard, RolesGuard],
-  exports: [UsersService],
+  providers: [
+    UsersService,
+    JwtAuthGuard,
+    RolesGuard,
+    ProfileCompletenessService,
+  ],
+  exports: [UsersService, ProfileCompletenessService],
 })
 export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -7,6 +7,10 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import {
+  PaginatedResponse,
+  PaginationService,
+} from '../common/pagination/index.js';
 import { User } from './entities/user.entity.js';
 import { Role } from './entities/role.entity.js';
 import { MentorProfile } from './entities/mentor-profile.entity.js';
@@ -38,6 +42,7 @@ export class UsersService {
     private readonly mentorProfileRepo: Repository<MentorProfile>,
     @InjectRepository(MenteeProfile)
     private readonly menteeProfileRepo: Repository<MenteeProfile>,
+    private readonly paginationService: PaginationService,
   ) {}
 
   async findById(id: string): Promise<User> {
@@ -325,20 +330,16 @@ export class UsersService {
     return saved;
   }
 
-  async findAll(
-    query: UserQueryDto,
-  ): Promise<{ data: User[]; total: number; page: number; limit: number }> {
-    const page = query.page ?? 1;
-    const limit = query.limit ?? 20;
+  async findAll(query: UserQueryDto): Promise<PaginatedResponse<User>> {
+    const qb = this.userRepo
+      .createQueryBuilder('user')
+      .leftJoinAndSelect('user.roles', 'roles')
+      .orderBy('user.createdAt', 'DESC');
 
-    const [data, total] = await this.userRepo.findAndCount({
-      where: query.status ? { status: query.status } : {},
-      relations: ['roles'],
-      skip: (page - 1) * limit,
-      take: limit,
-      order: { createdAt: 'DESC' },
-    });
+    if (query.status) {
+      qb.andWhere('user.status = :status', { status: query.status });
+    }
 
-    return { data, total, page, limit };
+    return this.paginationService.paginate(qb, query.page, query.limit);
   }
 }


### PR DESCRIPTION
## Summary

Implements four issues in a single PR:

### #1006 — DTO validation across all modules
- Added custom `class-validator` business-rule validators under `src/common/validators/`:
  - `IsValidWalletAddress` — validates Stellar public keys, reusing the existing `wallet.utils` normalization so DTO validation and service-layer normalization never drift apart.
  - `IsValidTimezone` — validates IANA timezone identifiers via the existing `timezone.utils`.
  - `IsAfterDate(property)` — generic cross-field validator ensuring one date field is after another.
  - `IsValidAvailabilitySlot` — cross-field validator ensuring `startTime`/`endTime` are well-formed `HH:MM` and `startTime` precedes `endTime`.
- Applied these to `WalletLoginDto`, the availability slot DTOs (`timezone`, `startTime`/`endTime`), and `CertificationDto.expirationDate` (must be after `issueDate`).
- Added a reusable `PaginationQueryDto` base class under `src/common/dto/`.
- Configured a global `ValidationPipe` `exceptionFactory` in `main.ts` that flattens `class-validator` errors into a stable `{ field, code, message }[]` shape, ready for client-side localization. `whitelist`, `forbidNonWhitelisted`, and `transform` were already enabled and remain in place.

### #1007 — Pagination utility service
- Added `PaginationService` (`src/common/pagination/`) with:
  - `paginate(source, page, limit, options)` — offset/limit pagination over a TypeORM `Repository` or `SelectQueryBuilder`, with a configurable max limit (default 100).
  - `paginateByCursor(qb, cursorColumn, options)` — cursor-based pagination for high-throughput scenarios.
  - `buildLinks(baseUrl, page, limit, totalPages)` — first/prev/next/last link helper.
- Added `PaginatedResponse<T>` / `PaginationMeta` interfaces standardizing `{ data, meta: { page, limit, total, totalPages, hasNext, hasPrev } }`.
- Registered `PaginationModule` globally in `AppModule`.
- Refactored `UserQueryDto` to extend `PaginationQueryDto`, and `UsersService.findAll` / `UsersController.listUsers` (`GET /user/admin`) to use `PaginationService`, so it now returns the standardized shape.

### #1004 — Profile completeness score
- Added `avatarUrl` to `User` (required field for mentor completeness; settable via `PATCH /user`), with migration.
- Added `ProfileCompletenessService`, computing a dynamic 0–100 score per profile type:
  - Mentor required fields: bio, skills, hourly rate, expertise areas, avatar, availability slots.
  - Mentee required fields: learning goals, skill level, areas of interest.
  - Optional-field bonus (up to +10%, capped at 110): portfolio links, education, certifications for mentors; portfolio links, professional background, job title for mentees.
  - Returns missing-field names + descriptions, and improvement suggestions when the base score is under 80.
- Cached in Redis for 5 minutes (registers the existing but previously-unused `RedisModule` in `AppModule`); invalidated on profile/user updates.
- New endpoints: `GET /user/profile/completeness` (self) and `GET /user/admin/completeness` (paginated, admin-only). `completenessScore` is now included in `GET /user`.

### #1005 — Featured mentor flag
- Added `isFeatured`, `featuredAt`, `featuredExpiresAt`, `featuredOrder` to `MentorProfile`, plus a composite `(isFeatured, featuredOrder)` index, with migration.
- Added `MentorFeatureAuditLog` (mirrors the existing `VerificationAuditLog` pattern), recording every feature/unfeature action, with migration.
- Added `MentorsModule`/`Service`/`Controller`:
  - `GET /mentors/featured` — public, paginated (via `PaginationService`), ordered by `featuredOrder`, excludes expired entries.
  - `POST /admin/mentors/:mentorId/feature` — admin-only, enforces a configurable max concurrent featured count (`FEATURED_MENTORS_MAX`, default 10) and sets a configurable expiry (`FEATURED_MENTORS_DURATION_DAYS`, default 30).
  - `DELETE /admin/mentors/:mentorId/unfeature` — admin-only.
  - Featured status lazily expires on read rather than requiring a cron job.

Closes #1006
Closes #1007
Closes #1004
Closes #1005

## Test plan

- [x] `npm run build` passes (verified with the pre-existing, unrelated `src/config2` duplicate-config folder set aside — it fails to build on `main` too and is unused/not wired into `AppModule`).
- [x] `npx eslint --fix` applied to all new/modified files; no remaining lint errors.
- [ ] Manual/unit testing was explicitly out of scope for this pass per the requester's instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)