### PR TITLE
feat(contract): emit upgrade, refund, auto-refund, and treasury events

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -3,9 +3,12 @@
 extern crate alloc;
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype,
-    Address, Bytes32, Env, symbol_short,
+    contract, contracterror, contractimpl, contracttype, panic_with_error,
+    Address, BytesN, Env, Symbol, symbol_short,
 };
+
+/// 32-byte identifier / wasm hash alias used across the contract API.
+pub type Bytes32 = BytesN<32>;
 
 // ---------------------------------------------------------------------------
 // Storage symbols
@@ -15,6 +18,9 @@ const TREASURY: &str = "TREASURY";
 const PLATFORM_FEE: &str = "PFEE";
 const INITIALIZED: &str = "INIT";
 const ARCHIVE_AFTER: &str = "ARCHAFT";
+
+/// Default dispute window (seconds) before a completed session may auto-refund.
+const DEFAULT_DISPUTE_WINDOW: u64 = 86_400;
 
 // ---------------------------------------------------------------------------
 // Error codes
@@ -103,6 +109,110 @@ pub struct Session {
 pub struct ArchivedSession {
     pub id: Bytes32,
     pub archived_at: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Emitted when the contract WASM is upgraded (admin-only).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractUpgraded {
+    pub old_wasm_hash: Bytes32,
+    pub new_wasm_hash: Bytes32,
+    pub upgraded_by: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted when a buyer successfully refunds a session (manual or auto).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionRefunded {
+    pub session_id: Bytes32,
+    pub buyer: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+/// Distinct event for timeout-based auto-refunds.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AutoRefundExecuted {
+    pub session_id: Bytes32,
+    pub buyer: Address,
+    pub amount: i128,
+    pub completed_at: u64,
+    pub refunded_at: u64,
+}
+
+/// Emitted when admin changes the treasury wallet.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TreasuryUpdated {
+    pub old_treasury: Address,
+    pub new_treasury: Address,
+    pub updated_by: Address,
+}
+
+fn emit_contract_upgraded(
+    env: &Env,
+    old_wasm_hash: Bytes32,
+    new_wasm_hash: Bytes32,
+    upgraded_by: Address,
+) {
+    let event = ContractUpgraded {
+        old_wasm_hash,
+        new_wasm_hash,
+        upgraded_by,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events()
+        .publish((Symbol::new(env, "ContractUpgraded"),), event);
+}
+
+fn emit_session_refunded(env: &Env, session_id: Bytes32, buyer: Address, amount: i128) {
+    let event = SessionRefunded {
+        session_id,
+        buyer,
+        amount,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events()
+        .publish((Symbol::new(env, "SessionRefunded"),), event);
+}
+
+fn emit_auto_refund_executed(
+    env: &Env,
+    session_id: Bytes32,
+    buyer: Address,
+    amount: i128,
+    completed_at: u64,
+) {
+    let event = AutoRefundExecuted {
+        session_id,
+        buyer,
+        amount,
+        completed_at,
+        refunded_at: env.ledger().timestamp(),
+    };
+    env.events()
+        .publish((Symbol::new(env, "AutoRefundExecuted"),), event);
+}
+
+fn emit_treasury_updated(
+    env: &Env,
+    old_treasury: Address,
+    new_treasury: Address,
+    updated_by: Address,
+) {
+    let event = TreasuryUpdated {
+        old_treasury,
+        new_treasury,
+        updated_by,
+    };
+    env.events()
+        .publish((Symbol::new(env, "TreasuryUpdated"),), event);
 }
 
 // ---------------------------------------------------------------------------
@@ -296,6 +406,73 @@ impl SkillsyncContract {
     }
 
     // -----------------------------------------------------------------------
+    // Refunds
+    // -----------------------------------------------------------------------
+
+    /// Buyer-initiated refund while the session is still Locked.
+    /// Emits `SessionRefunded`.
+    pub fn refund_session(env: Env, session_id: Bytes32) {
+        require_initialized(&env);
+        let mut session = get_session(&env, &session_id)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::SessionNotFound));
+
+        if session.status == SessionStatus::Refunded {
+            panic_with_error!(&env, ContractError::SessionAlreadyRefunded);
+        }
+        if session.status != SessionStatus::Locked {
+            panic_with_error!(&env, ContractError::InvalidStatus);
+        }
+
+        session.buyer.require_auth();
+
+        let buyer = session.buyer.clone();
+        let amount = session.amount;
+        session.status = SessionStatus::Refunded;
+        save_session(&env, &session_id, &session);
+
+        emit_session_refunded(&env, session_id, buyer, amount);
+    }
+
+    /// Timeout auto-refund for sessions stuck in Completed beyond the dispute window.
+    /// Emits both `SessionRefunded` and `AutoRefundExecuted`.
+    pub fn auto_refund(env: Env, session_id: Bytes32) {
+        require_initialized(&env);
+        let mut session = get_session(&env, &session_id)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::SessionNotFound));
+
+        if session.status == SessionStatus::Refunded {
+            panic_with_error!(&env, ContractError::SessionAlreadyRefunded);
+        }
+        if session.status != SessionStatus::Completed {
+            panic_with_error!(&env, ContractError::InvalidStatus);
+        }
+
+        let completed_at = session
+            .completed_at
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::InvalidSessionState));
+
+        let dispute_window: u64 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("DSPWND"))
+            .unwrap_or(DEFAULT_DISPUTE_WINDOW);
+
+        let now = env.ledger().timestamp();
+        if now <= completed_at + dispute_window {
+            panic_with_error!(&env, ContractError::InvalidStatus);
+        }
+
+        let buyer = session.buyer.clone();
+        let amount = session.amount;
+        session.status = SessionStatus::Refunded;
+        save_session(&env, &session_id, &session);
+
+        // SessionRefunded is emitted for both manual and auto refunds.
+        emit_session_refunded(&env, session_id.clone(), buyer.clone(), amount);
+        emit_auto_refund_executed(&env, session_id, buyer, amount, completed_at);
+    }
+
+    // -----------------------------------------------------------------------
     // Issue #965 — Storage cleanup and archiving
     // -----------------------------------------------------------------------
 
@@ -390,12 +567,44 @@ impl SkillsyncContract {
     // Admin helpers
     // -----------------------------------------------------------------------
 
+    /// Upgrade contract WASM. Admin only. Emits `ContractUpgraded`.
+    pub fn upgrade(env: Env, new_wasm_hash: Bytes32) {
+        require_initialized(&env);
+        let admin = require_admin(&env);
+
+        let old_wasm_hash: Bytes32 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("WASMHASH"))
+            .unwrap_or_else(|| BytesN::from_array(&env, &[0; 32]));
+
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("WASMHASH"), &new_wasm_hash);
+
+        emit_contract_upgraded(
+            &env,
+            old_wasm_hash,
+            new_wasm_hash.clone(),
+            admin,
+        );
+
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash);
+    }
+
     pub fn set_treasury(env: Env, new_treasury: Address) {
         require_initialized(&env);
-        require_admin(&env);
+        let updated_by = require_admin(&env);
+        let old_treasury: Address = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("TRSY"))
+            .unwrap();
         env.storage()
             .persistent()
             .set(&symbol_short!("TRSY"), &new_treasury);
+        emit_treasury_updated(&env, old_treasury, new_treasury, updated_by);
     }
 
     pub fn get_treasury(env: Env) -> Address {
@@ -448,7 +657,7 @@ impl SkillsyncContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Env, Bytes32};
+    use soroban_sdk::{testutils::Address as _, Env};
 
     fn setup() -> (Env, SkillsyncContractClient<'static>, Address, Address) {
         let env = Env::default();


### PR DESCRIPTION
## Summary

Adds typed Soroban contract events for upgradeability, refunds, and treasury admin updates so off-chain indexers can monitor protocol state changes.


## Changes

### Event — ContractUpgraded (#935)
- Added `ContractUpgraded { old_wasm_hash, new_wasm_hash, upgraded_by, timestamp }`
- Emitted from new admin-only `upgrade(new_wasm_hash)` via `update_current_contract_wasm`
- Persists wasm hash so subsequent upgrades report the correct previous hash

### Event — SessionRefunded (#928)
- Added `SessionRefunded { session_id, buyer, amount, timestamp }`
- Emitted from `refund_session()` (manual buyer refund while Locked)
- Also emitted from `auto_refund()` so both refund paths are observable

### Event — AutoRefundExecuted (#929)
- Added `AutoRefundExecuted { session_id, buyer, amount, completed_at, refunded_at }`
- Emitted only from timeout-based `auto_refund()` after the dispute window elapses
- Enables tracking of failed/stuck completions separately from manual refunds

### Event — TreasuryUpdated (#933)
- Added `TreasuryUpdated { old_treasury, new_treasury, updated_by }`
- Emitted during `set_treasury()` with previous and new treasury addresses

## Test plan
- [ ] `set_treasury` publishes `TreasuryUpdated` with old/new/updated_by
- [ ] `refund_session` on a Locked session publishes `SessionRefunded`
- [ ] `auto_refund` after dispute window publishes both `SessionRefunded` and `AutoRefundExecuted`
- [ ] `upgrade` (admin) publishes `ContractUpgraded` with old/new wasm hashes
- [ ] Non-admin upgrade / non-buyer refund still unauthorized

closes #928 
closes #929 
closes #933 
closes #935