### PR TITLE
Add global API response formatter interceptor

### DIFF
--- a/backend/src/common/interceptors/response.interceptor.ts
+++ b/backend/src/common/interceptors/response.interceptor.ts
@@ -1,0 +1,65 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, map } from 'rxjs';
+import { Request } from 'express';
+
+export interface ApiResponse<T> {
+  success: boolean;
+  statusCode: number;
+  message: string;
+  data: T;
+  timestamp: string;
+  path: string;
+}
+
+export interface PaginatedData<T> {
+  items: T[];
+  meta: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrev: boolean;
+  };
+}
+
+@Injectable()
+export class ResponseInterceptor<T> implements NestInterceptor<T, ApiResponse<T>> {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<ApiResponse<T>> {
+    const ctx = context.switchToHttp();
+    const request = ctx.getRequest<Request>();
+    const statusCode = ctx.getResponse().statusCode;
+
+    return next.handle().pipe(
+      map((data) => {
+        if (data && typeof data === 'object' && 'meta' in data && 'data' in data) {
+          return {
+            success: true,
+            statusCode,
+            message: 'Success',
+            data: {
+              items: data.data,
+              meta: data.meta,
+            },
+            timestamp: new Date().toISOString(),
+            path: request.originalUrl,
+          };
+        }
+
+        return {
+          success: true,
+          statusCode,
+          message: 'Success',
+          data: data ?? null,
+          timestamp: new Date().toISOString(),
+          path: request.originalUrl,
+        };
+      }),
+    );
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { BadRequestException, ValidationPipe } from '@nestjs/common';
 import { ValidationError } from 'class-validator';
 import { AppModule } from './app.module.js';
+import { ResponseInterceptor } from './common/interceptors/response.interceptor.js';
 
 function flattenValidationErrors(
   errors: ValidationError[],
@@ -41,6 +42,11 @@ async function bootstrap() {
     allowedHeaders: ['Authorization', 'Content-Type', 'Accept'],
     credentials: true,
   });
+
+  // -----------------------------------------------------------------------
+  // Global response interceptor (#1008)
+  // -----------------------------------------------------------------------
+  app.useGlobalInterceptors(new ResponseInterceptor());
 
   // -----------------------------------------------------------------------
   // Global pipes


### PR DESCRIPTION
## Summary

Implemented a global response interceptor that wraps all successful responses in a standardized envelope for predictable frontend consumption.

### Changes

- Created `src/common/interceptors/response.interceptor.ts` with `ApiResponse` and `PaginatedData` interfaces
- Registers globally in `main.ts`
- Wraps all responses in `{ success, statusCode, message, data, timestamp, path }` format
- Paginated responses detected automatically and nested under `data.items` with `data.meta`
- Works alongside existing `GlobalExceptionFilter` for consistent error responses

Closes #1008
Closes #1010
Closes #1009
Closes #964